### PR TITLE
Add inline image display in CSV exports

### DIFF
--- a/routes/bulles.js
+++ b/routes/bulles.js
@@ -130,8 +130,16 @@ router.get("/export/csv/all", async (req, res) => {
       eol: "\r\n"
     };
 
+    const baseUrl = req.protocol + "://" + req.get("host");
+    const rowsWithFullPhoto = result.rows.map(row => {
+      return {
+        ...row,
+        photo: row.photo ? `=IMAGE("${baseUrl}${row.photo}")` : ""
+      };
+    });
+
     const json2csvParser = new Parser(opts);
-    let csv = json2csvParser.parse(result.rows);
+    let csv = json2csvParser.parse(rowsWithFullPhoto);
 
     const BOM = '\uFEFF';
     csv = BOM + csv;
@@ -162,7 +170,7 @@ router.get("/export/csv", async (req, res) => {
     const rowsWithFullPhoto = result.rows.map(row => {
       return {
         ...row,
-        photo: row.photo ? `${baseUrl}${row.photo}` : ""
+        photo: row.photo ? `=IMAGE("${baseUrl}${row.photo}")` : ""
       };
     });
 


### PR DESCRIPTION
## Summary
- export CSV with the `photo` column as an IMAGE formula

## Testing
- `node --check routes/bulles.js`

------
https://chatgpt.com/codex/tasks/task_e_68526f0625a88327abd6806f4d2ae530