### PR TITLE
Add inline image formula with absolute paths

### DIFF
--- a/routes/bulles.js
+++ b/routes/bulles.js
@@ -130,8 +130,19 @@ router.get("/export/csv/all", async (req, res) => {
       eol: "\r\n"
     };
 
+    const baseUrl = req.protocol + "://" + req.get("host");
+    const photoFormula = (photo) => {
+      if (!photo) return "";
+      const url = /^https?:\/\//.test(photo) ? photo : baseUrl + photo;
+      return `=IMAGE("${url}")`;
+    };
+    const rowsWithFullPhoto = result.rows.map(row => ({
+      ...row,
+      photo: photoFormula(row.photo)
+    }));
+
     const json2csvParser = new Parser(opts);
-    let csv = json2csvParser.parse(result.rows);
+    let csv = json2csvParser.parse(rowsWithFullPhoto);
 
     const BOM = '\uFEFF';
     csv = BOM + csv;
@@ -159,12 +170,15 @@ router.get("/export/csv", async (req, res) => {
 
     // Convertir chemins photo en URL complètes (exemple ici : base URL à adapter)
     const baseUrl = req.protocol + "://" + req.get("host");
-    const rowsWithFullPhoto = result.rows.map(row => {
-      return {
-        ...row,
-        photo: row.photo ? `${baseUrl}${row.photo}` : ""
-      };
-    });
+    const photoFormula = (photo) => {
+      if (!photo) return "";
+      const url = /^https?:\/\//.test(photo) ? photo : baseUrl + photo;
+      return `=IMAGE("${url}")`;
+    };
+    const rowsWithFullPhoto = result.rows.map(row => ({
+      ...row,
+      photo: photoFormula(row.photo)
+    }));
 
     const fields = [
       "id", "numero", "intitule", "description", "etat",

--- a/server.js
+++ b/server.js
@@ -15,7 +15,8 @@ app.use(cors({
 }));
 
 app.use(express.json());
-app.use('/uploads', express.static('uploads'));
+// Servir les fichiers uploadés (chemin absolu pour éviter les 404)
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 
 // Configuration express-session
@@ -30,8 +31,6 @@ app.use(session({
   },
 }));
 
-// Servir les fichiers uploadés
-app.use("/uploads", express.static(path.join(__dirname, "uploads")));
 // Servir les fichiers statiques front (html, css, js)
 app.use(express.static(path.join(__dirname, "public")));
 


### PR DESCRIPTION
## Summary
- serve `/uploads` via an absolute path
- export CSV photo column using a helper to handle external links

## Testing
- `node --check routes/bulles.js`


------
https://chatgpt.com/codex/tasks/task_e_68526f0625a88327abd6806f4d2ae530