### PR TITLE
Fix mobile popup to full screen

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -203,16 +203,20 @@ button:hover {
   }
 
   .popup {
-    left: 5% !important;
-    right: 5% !important;
-    top: auto !important;
-    bottom: 20px;
-    transform: none;
-    width: 90% !important;
+    position: fixed !important;
+    left: 0 !important;
+    right: 0 !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    width: 100% !important;
+    height: 100vh !important;
     max-width: none;
-    max-height: 90vh;
+    max-height: none;
+    margin: 0;
+    transform: none;
     overflow-y: auto;
-    padding: 12px;
+    padding: 16px;
+    border-radius: 0;
   }
 
   .popup input, .popup textarea, .popup select {


### PR DESCRIPTION
## Summary
- update responsive popup CSS so popup covers entire screen on small devices

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685411a87c408327ba3e443599391b8d