### PR TITLE
Add local user tracking and history

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,29 @@
 <body>
   <header>
     <h1>Plan interactif</h1>
+  
+  <label>Utilisateur :
+    <select id="userSelect">
+      <option value="">-- Sélectionner --</option>
+      <option>ATHARI Keivan</option>
+      <option>BLOT Valentin</option>
+      <option>COULIBALY Baba</option>
+      <option>DA COSTA André</option>
+      <option>GOURDEL Yoann</option>
+      <option>GUEGAN Maxime</option>
+      <option>LAUNAY Jérémy</option>
+      <option>MARZOUKI Adam</option>
+      <option>MAZZUCCO Ryan</option>
+      <option>PENA Angel</option>
+      <option>PEREIRA Romain</option>
+      <option>RADWAN Mahmoud</option>
+      <option>ROUAULT Christophe</option>
+      <option>TABLETTE DÉPÔT</option>
+      <option>VAUTHIER Philippe</option>
+      <option>VAZ Xavier</option>
+    </select>
+  </label>
+  <button id="historiqueBtn">Historique</button>
   </header>
 
   <!-- FORMULAIRE LOGIN -->


### PR DESCRIPTION
## Summary
- add user selection drop-down and history button in UI
- store selected user and actions in localStorage
- track bubble creation, update and deletion with user info
- allow viewing recorded actions in a popup

## Testing
- `node --check public/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68592dfc10348327b8f3212ee7163364