### PR TITLE
Display bubble details in history

### DIFF
--- a/public/historique.html
+++ b/public/historique.html
@@ -18,6 +18,8 @@
           <th>Utilisateur</th>
           <th>Action</th>
           <th>Emplacement</th>
+          <th>Bulle</th>
+          <th>Description</th>
           <th>Date/Heure</th>
         </tr>
       </thead>

--- a/public/historique.js
+++ b/public/historique.js
@@ -5,7 +5,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (actions.length === 0) {
     const row = document.createElement('tr');
     const cell = document.createElement('td');
-    cell.colSpan = 4;
+    cell.colSpan = 6;
     cell.textContent = 'Aucune action enregistrée.';
     row.appendChild(cell);
     tbody.appendChild(row);
@@ -17,7 +17,14 @@ window.addEventListener('DOMContentLoaded', () => {
         ? `${a.etage} / ${a.chambre}`
         : `${a.etage} (${Number(a.x).toFixed(2)}, ${Number(a.y).toFixed(2)})`;
 
-      const values = [a.user, a.action, emplacement, new Date(a.timestamp).toLocaleString()];
+      const values = [
+        a.user,
+        a.action,
+        emplacement,
+        a.nomBulle || '',
+        a.description || '',
+        new Date(a.timestamp).toLocaleString()
+      ];
       values.forEach((val, idx) => {
         const td = document.createElement('td');
         td.textContent = val;


### PR DESCRIPTION
## Summary
- add columns for bubble name and description
- track `nomBulle` and `description` in localStorage
- show the extra details on the history page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859446161b883279afa5740ed7fbe35