### PR TITLE
Add dashboard and API endpoints

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Dashboard</h1>
+    <nav>
+      <a href="index.html">Accueil</a>
+    </nav>
+  </header>
+  <main>
+    <section id="cards" style="display:flex; gap:20px; flex-wrap:wrap; justify-content:center;">
+      <div class="card" data-etat="attente">Attente: <span class="value">0</span></div>
+      <div class="card" data-etat="a_corriger">A corriger: <span class="value">0</span></div>
+      <div class="card" data-etat="corrige">Corrigé: <span class="value">0</span></div>
+      <div class="card" data-etat="validee">Validée: <span class="value">0</span></div>
+    </section>
+    <section id="urgent" style="margin-top:30px;">
+      <h2>Bulles urgentes</h2>
+      <table>
+        <thead>
+          <tr><th>ID</th><th>Description</th><th>Date butoir</th><th>Détail</th></tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
+    </section>
+  </main>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,42 @@
+window.addEventListener('DOMContentLoaded', () => {
+  loadStats();
+  loadUrgent();
+});
+
+function loadStats() {
+  fetch('/api/bulles/stats')
+    .then(res => {
+      if (!res.ok) throw new Error('Erreur stats');
+      return res.json();
+    })
+    .then(data => {
+      document.querySelectorAll('#cards .card').forEach(card => {
+        const etat = card.getAttribute('data-etat');
+        card.querySelector('.value').textContent = data[etat] ?? 0;
+      });
+    })
+    .catch(() => {
+      document.getElementById('cards').textContent = 'Impossible de charger les statistiques.';
+    });
+}
+
+function loadUrgent() {
+  fetch('/api/bulles/urgent')
+    .then(res => {
+      if (!res.ok) throw new Error('Erreur urgent');
+      return res.json();
+    })
+    .then(data => {
+      const tbody = document.querySelector('#urgent tbody');
+      tbody.innerHTML = '';
+      data.forEach(bulle => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${bulle.id}</td><td>${bulle.description || ''}</td><td>${bulle.date_butoir ? bulle.date_butoir.substring(0,10) : ''}</td><td><a href="detail.html?id=${bulle.id}">Voir</a></td>`;
+        tbody.appendChild(tr);
+      });
+    })
+    .catch(() => {
+      const tbody = document.querySelector('#urgent tbody');
+      tbody.innerHTML = '<tr><td colspan="4">Erreur de chargement</td></tr>';
+    });
+}

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
     </select>
   </label>
   <button id="historiqueBtn">Historique</button>
+  <a href="dashboard.html">Dashboard</a>
   </header>
 
   <!-- FORMULAIRE LOGIN -->

--- a/routes/bulles.js
+++ b/routes/bulles.js
@@ -204,4 +204,35 @@ router.get("/export/csv", async (req, res) => {
   }
 });
 
+// GET /api/bulles/stats
+//   renvoie {attente: X, a_corriger: Y, corrige: Z, validee: W}
+router.get('/stats', async (req, res) => {
+  try {
+    const result = await pool.query("SELECT etat, COUNT(*) FROM bulles GROUP BY etat");
+    const stats = { attente: 0, a_corriger: 0, corrige: 0, validee: 0 };
+    result.rows.forEach(r => {
+      stats[r.etat] = parseInt(r.count, 10);
+    });
+    res.json(stats);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur stats' });
+  }
+});
+
+// GET /api/bulles/urgent
+//   renvoie un tableau des 5 bulles où etat != 'validee'
+//   triées par due_date ASC
+router.get('/urgent', async (req, res) => {
+  try {
+    const result = await pool.query(
+      "SELECT id, description, date_butoir FROM bulles WHERE etat <> 'validee' ORDER BY date_butoir ASC LIMIT 5"
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur urgent' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- create dashboard.html and dashboard.js
- display stats and urgent tasks
- add `/api/bulles/stats` and `/api/bulles/urgent`
- link dashboard in index.html

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cf5e486108327b881eeaa38c3119a