### PR TITLE
Fix users query and client username display

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -50,7 +50,7 @@ async function loadUsers() {
   const users = await res.json();
   userSelect.innerHTML =
     '<option value="">-- Choisir un employé --</option>' +
-    users.map(u => `<option value="${u.id}">${u.fullName}</option>`).join('');
+    users.map(u => `<option value="${u.id}">${u.username}</option>`).join('');
 }
 
 async function loadFloors() {

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,9 +3,9 @@ const router = express.Router();
 const pool = require("../db");
 
 // GET /api/users
-// Sélectionne id et fullName depuis la table "users"
+// Sélectionne id et username depuis la table "users"
 router.get('/', async (req, res) => {
-  const { rows } = await pool.query('SELECT id, fullName FROM users');
+  const { rows } = await pool.query('SELECT id, username FROM users');
   res.json(rows);
 });
 


### PR DESCRIPTION
## Summary
- select `id` and `username` instead of `fullName` in `GET /api/users`
- display usernames in user dropdown

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d492b0edc832794cf981a159a6b05