### PR TITLE
Fix missing interventions table and list

### DIFF
--- a/migrations/003_create_interventions.sql
+++ b/migrations/003_create_interventions.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS interventions (
+  id SERIAL PRIMARY KEY,
+  user_id    INTEGER NOT NULL,
+  floor_id   TEXT    NOT NULL,
+  room_id    TEXT    NOT NULL,
+  lot        TEXT    NOT NULL,
+  task       TEXT    NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/public/selection.html
+++ b/public/selection.html
@@ -43,6 +43,15 @@
         <select id="task-select"><option value="">--D'abord choisir un lot--</option></select>
       </label>
       <button id="submit-selection">Valider</button>
+      <h2>Historique des interventions validées</h2>
+      <table id="interventions-table">
+        <thead>
+          <tr>
+            <th>ID</th><th>Employé</th><th>Étage</th><th>Chambre</th><th>Lot</th><th>Tâche</th><th>Date</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
   </main>
   <script src="selection.js"></script>

--- a/public/selection.js
+++ b/public/selection.js
@@ -45,6 +45,25 @@ const lotSelect   = document.getElementById('lot-select');
 const taskSelect  = document.getElementById('task-select');
 const submitBtn   = document.getElementById('submit-selection');
 
+async function loadInterventions() {
+  const res = await fetch('/api/interventions');
+  const data = await res.json();
+  const tbody = document.querySelector('#interventions-table tbody');
+  tbody.innerHTML = data
+    .map(i => `
+      <tr>
+        <td>${i.id}</td>
+        <td>${i.user_id}</td>
+        <td>${i.floor_id}</td>
+        <td>${i.room_id}</td>
+        <td>${i.lot}</td>
+        <td>${i.task}</td>
+        <td>${new Date(i.created_at).toLocaleString()}</td>
+      </tr>
+    `)
+    .join('');
+}
+
 async function loadUsers() {
   const res = await fetch('/api/users');
   const users = await res.json();
@@ -102,9 +121,11 @@ submitBtn.addEventListener('click', async () => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
+  await loadInterventions();
 });
 
 window.addEventListener('DOMContentLoaded', async () => {
   await loadUsers();
   await loadFloors();
+  await loadInterventions();
 });

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -57,4 +57,12 @@ router.post('/interventions', async (req, res) => {
   }
 });
 
+// GET /api/interventions
+router.get('/interventions', async (req, res) => {
+  const { rows } = await pool.query(
+    'SELECT * FROM interventions ORDER BY created_at DESC'
+  );
+  res.json(rows);
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- create migrations/003_create_interventions.sql for interventions table
- expose GET `/api/interventions` in routes
- show interventions history table in selection.html
- load interventions on page load and after submit

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e66c67bc08327b6251a257c7e0745