### PR TITLE
Create interventions table and list endpoint

### DIFF
--- a/migrations/003_create_interventions.sql
+++ b/migrations/003_create_interventions.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS interventions (
   id SERIAL PRIMARY KEY,
-  user_id    INTEGER NOT NULL,
-  floor_id   TEXT    NOT NULL,
-  room_id    TEXT    NOT NULL,
-  lot        TEXT    NOT NULL,
-  task       TEXT    NOT NULL,
-  created_at TIMESTAMPTZ DEFAULT now()
+  user_id    TEXT      NOT NULL,
+  floor_id   TEXT      NOT NULL,
+  room_id    TEXT      NOT NULL,
+  lot        TEXT      NOT NULL,
+  task       TEXT      NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -60,7 +60,7 @@ router.post('/interventions', async (req, res) => {
 // GET /api/interventions
 router.get('/interventions', async (req, res) => {
   const { rows } = await pool.query(
-    'SELECT * FROM interventions ORDER BY created_at DESC'
+    'SELECT id, user_id, floor_id, room_id, lot, task, created_at FROM interventions ORDER BY created_at DESC'
   );
   res.json(rows);
 });


### PR DESCRIPTION
## Summary
- fix migration for `interventions` table
- query explicit columns in GET /api/interventions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e6ac7323c83279e9ccd7590da89df