### PR TITLE
Remove duplicate GET /interventions route

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -57,13 +57,6 @@ router.post('/interventions', async (req, res) => {
   }
 });
 
-// GET /api/interventions
-router.get('/interventions', async (req, res) => {
-  const { rows } = await pool.query(
-    'SELECT id, user_id, floor_id, room_id, lot, task, created_at FROM interventions ORDER BY created_at DESC'
-  );
-  res.json(rows);
-});
 
 // GET /api/interventions — liste toutes les interventions
 router.get('/', async (req, res) => {


### PR DESCRIPTION
## Summary
- clean up routes/interventions.js
- remove duplicate `/interventions` GET endpoint so only `GET /api/interventions` remains

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e700cc7a083279387d2d96afe5acd