### PR TITLE
Fix POST route path and show confirmation

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -116,11 +116,14 @@ submitBtn.addEventListener('click', async () => {
     lot: lotSelect.value,
     task: taskSelect.value
   };
-  await fetch('/api/interventions', {
+  const res = await fetch('/api/interventions', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
+  if (res.ok) {
+    alert('Intervention enregistrée !');
+  }
   await loadInterventions();
 });
 

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -40,7 +40,7 @@ router.get('/users', async (req, res) => {
 });
 
 // POST new intervention
-router.post('/interventions', async (req, res) => {
+router.post('/', async (req, res) => {
   const { floorId, roomId, userId, lot, task } = req.body;
   if (!floorId || !roomId || !userId || !lot || !task) {
     return res.status(400).json({ error: 'Données manquantes' });


### PR DESCRIPTION
## Summary
- correct POST route path for interventions
- give confirmation alert on successful POST

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685e72881520832784446b7ba4241491