### PR TITLE
Fix interventions history display

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -43,12 +43,10 @@
         <select id="task-select"><option value="">--D'abord choisir un lot--</option></select>
       </label>
       <button id="submit-selection">Valider</button>
-      <h2>Historique des interventions validées</h2>
+      <h2>Historique des interventions</h2>
       <table id="interventions-table">
         <thead>
-          <tr>
-            <th>ID</th><th>Employé</th><th>Étage</th><th>Chambre</th><th>Lot</th><th>Tâche</th><th>Date</th>
-          </tr>
+          <tr><th>ID</th><th>Employé</th><th>Étage</th><th>Chambre</th><th>Lot</th><th>Tâche</th><th>Date</th></tr>
         </thead>
         <tbody></tbody>
       </table>

--- a/server.js
+++ b/server.js
@@ -9,6 +9,21 @@ const interventionsRoutes = require("./routes/interventions");
 const usersRoutes = require("./routes/users");
 const floorsRoutes = require("./routes/floors");
 const roomsRoutes = require("./routes/rooms");
+const pool = require("./db");
+
+(async () => {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS interventions (
+      id         SERIAL       PRIMARY KEY,
+      user_id    TEXT         NOT NULL,
+      floor_id   TEXT         NOT NULL,
+      room_id    TEXT         NOT NULL,
+      lot        TEXT         NOT NULL,
+      task       TEXT         NOT NULL,
+      created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+    );
+  `);
+})().catch(console.error);
 
 const app = express();
 


### PR DESCRIPTION
## Summary
- auto-create `interventions` table on startup
- show interventions history table on task page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e746379708327ae004d5cf1280b1b