### PR TITLE
Load interventions on task page

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -47,6 +47,10 @@ const submitBtn   = document.getElementById('submit-selection');
 
 async function loadInterventions() {
   const res = await fetch('/api/interventions');
+  if (!res.ok) {
+    console.error('Erreur fetch historique', res.status);
+    return;
+  }
   const data = await res.json();
   const tbody = document.querySelector('#interventions-table tbody');
   tbody.innerHTML = data


### PR DESCRIPTION
## Summary
- show error when fetching interventions fails
- update the interventions list when the page loads or after submitting

## Testing
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_685e8189e12c832791841f286b2237fc