### PR TITLE
Add debug logs in intervention loader

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -46,14 +46,19 @@ const taskSelect  = document.getElementById('task-select');
 const submitBtn   = document.getElementById('submit-selection');
 
 async function loadInterventions() {
+  console.log('Appel loadInterventions');
   const res = await fetch('/api/interventions');
+  console.log('GET /api/interventions status:', res.status);
   if (!res.ok) {
     console.error('Erreur fetch historique', res.status);
     return;
   }
   const data = await res.json();
-  const tbody = document.querySelector('#interventions-table tbody');
-  tbody.innerHTML = data
+  console.log('Données reçues:', data);
+  const interventions = Array.isArray(data) ? data : data.rows || [];
+  const tbody = document.getElementById('interventions-table').querySelector('tbody');
+  console.log('tbody trouvé:', tbody);
+  tbody.innerHTML = interventions
     .map(i => `
       <tr>
         <td>${i.id}</td>


### PR DESCRIPTION
## Summary
- improve instrumentation for `/api/interventions` fetches
- show how `tbody` is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e852d69fc832783adfa9511845688