### PR TITLE
Add status selection and employee names

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -42,11 +42,21 @@
       <label>Tâche :
         <select id="task-select"><option value="">--D'abord choisir un lot--</option></select>
       </label>
+      <label>État :
+        <select id="status-select">
+          <option value="">--Choisir un état--</option>
+          <option value="ouvert">Ouvert</option>
+          <option value="en_cours">En cours</option>
+          <option value="attente_validation">En attente de validation</option>
+          <option value="clos">Clos</option>
+          <option value="valide">Validé</option>
+        </select>
+      </label>
       <button id="submit-selection">Valider</button>
       <h2>Historique des interventions</h2>
       <table id="interventions-table">
         <thead>
-          <tr><th>ID</th><th>Employé</th><th>Étage</th><th>Chambre</th><th>Lot</th><th>Tâche</th><th>Date</th></tr>
+          <tr><th>ID</th><th>Employé</th><th>Étage</th><th>Chambre</th><th>Lot</th><th>Tâche</th><th>État</th><th>Date</th></tr>
         </thead>
         <tbody></tbody>
       </table>

--- a/public/selection.js
+++ b/public/selection.js
@@ -43,6 +43,7 @@ const floorSelect = document.getElementById('floor-select');
 const roomSelect  = document.getElementById('room-select');
 const lotSelect   = document.getElementById('lot-select');
 const taskSelect  = document.getElementById('task-select');
+const statusSelect = document.getElementById('status-select');
 const submitBtn   = document.getElementById('submit-selection');
 
 async function loadInterventions() {
@@ -62,11 +63,12 @@ async function loadInterventions() {
     .map(i => `
       <tr>
         <td>${i.id}</td>
-        <td>${i.user_id}</td>
+        <td>${window.userMap[i.user_id] || i.user_id}</td>
         <td>${i.floor_id}</td>
         <td>${i.room_id}</td>
         <td>${i.lot}</td>
         <td>${i.task}</td>
+        <td>${i.status}</td>
         <td>${new Date(i.created_at).toLocaleString()}</td>
       </tr>
     `)
@@ -76,6 +78,7 @@ async function loadInterventions() {
 async function loadUsers() {
   const res = await fetch('/api/users');
   const users = await res.json();
+  window.userMap = users.reduce((m, u) => (m[u.id] = u.username, m), {});
   userSelect.innerHTML =
     '<option value="">-- Choisir un employé --</option>' +
     users.map(u => `<option value="${u.id}">${u.username}</option>`).join('');
@@ -123,7 +126,8 @@ submitBtn.addEventListener('click', async () => {
     roomId: roomSelect.value,
     userId: userSelect.value,
     lot: lotSelect.value,
-    task: taskSelect.value
+    task: taskSelect.value,
+    status: statusSelect.value
   };
   const res = await fetch('/api/interventions', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- add Status dropdown to task page
- send selected status with intervention payload
- map user id to username
- show employee name and status in interventions table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ec239a24c8327bb80908b1cdb1f3d