### PR TITLE
Use puppeteer-core for serverless chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "json2csv": "^6.0.0-alpha.2",
     "multer": "^1.4.5-lts.1",
     "pg": "^8.11.3",
-    "puppeteer": "^21.0.0"
+    "puppeteer-core": "^21.0.0",
+    "chrome-aws-lambda": "^18.1.1"
   }
 }

--- a/routes/chantier.js
+++ b/routes/chantier.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const { isAuthenticated: ensureAuthenticated } = require('../middlewares/auth');
-const puppeteer = require('puppeteer');
+const chromium = require('chrome-aws-lambda');
+const puppeteer = require('puppeteer-core');
 
 // Export PDF route
 router.get('/export-pdf', ensureAuthenticated, async (req, res, next) => {
@@ -11,7 +12,11 @@ router.get('/export-pdf', ensureAuthenticated, async (req, res, next) => {
     const url = `${protocol}://${host}/chantier?` + Object.entries(req.query)
       .map(([k,v])=>`${k}=${encodeURIComponent(v)}`)
       .join('&');
-    const browser = await puppeteer.launch({ args: ['--no-sandbox','--disable-setuid-sandbox'] });
+    const browser = await puppeteer.launch({
+      args: chromium.args,
+      executablePath: await chromium.executablePath,
+      headless: chromium.headless,
+    });
     const page = await browser.newPage();
     await page.goto(url, { waitUntil: 'networkidle0' });
     const pdfBuffer = await page.pdf({ format: 'A4', printBackground: true });


### PR DESCRIPTION
## Summary
- replace `puppeteer` with `puppeteer-core`
- add `chrome-aws-lambda`
- configure Puppeteer to use the lambda chromium binary

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862879777b883278eec215aa47940b8