### PR TITLE
Fix chambre dropdown refresh

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -83,11 +83,9 @@
   function loadBulles() {
     bullesContainer.innerHTML = "";
 
-    const etage = etageSelect.value;
-    changePlan(etage);
-    updateChambreOptions(etage);
+    changePlan(etageSelect.value);
 
-    let url = `/api/bulles?etage=${encodeURIComponent(etage)}`;
+    let url = `/api/bulles?etage=${encodeURIComponent(etageSelect.value)}`;
     if (chambreSelect.value !== "total") {
       url += `&chambre=${chambreSelect.value}`;
     }
@@ -501,7 +499,8 @@
 
   chambreSelect.addEventListener("change", loadBulles);
   etageSelect.addEventListener("change", () => {
-    chambreSelect.dataset.etage = etageSelect.value;
+    changePlan(etageSelect.value);
+    updateChambreOptions(etageSelect.value);
     loadBulles();
   });
 


### PR DESCRIPTION
## Summary
- keep chambre selection when refreshing bubbles
- update floor change listener to reload room options

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863f3ec6c0083279ccb9be597e8de5a