### PR TITLE
Add reserve history migration & Cloudinary config

### DIFF
--- a/migrations/004_create_reserve_history.sql
+++ b/migrations/004_create_reserve_history.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS reserve_history (
+  id SERIAL PRIMARY KEY,
+  bulle_id INTEGER NOT NULL REFERENCES bulles(id) ON DELETE CASCADE,
+  user_id TEXT,
+  action_type TEXT NOT NULL,
+  old_values JSONB,
+  new_values JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
-const express = require("express");
 require("dotenv").config();
+const express = require("express");
 const multer = require("multer");
 const path = require("path");
 const cors = require("cors");
@@ -13,7 +13,7 @@ const floorsRoutes = require("./routes/floors");
 const roomsRoutes = require("./routes/rooms");
 const pool = require("./db");
 
-cloudinary.config(process.env.CLOUDINARY_URL);
+cloudinary.config('cloudinary://523438194377183:yBZ99NdGjYMFNrkMHHjImF3RBi4@dyp93ivlg');
 const storage = new CloudinaryStorage({
   cloudinary,
   params: {


### PR DESCRIPTION
## Summary
- add migration for `reserve_history`
- load env first in `server.js`
- configure Cloudinary with provided credentials

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864e68d88f08327948bf7e934a01ec5