### PR TITLE
Configure cloudinary via environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 PORT=3000
 DATABASE_URL=postgresql://reception_db_user:lNH2nQYD2M6Dev3QEHWGvTE3ak4DdkGR@dpg-d139vrk9c44c7392jsug-a.frankfurt-postgres.render.com/reception_db
+CLOUDINARY_URL=cloudinary://523438194377183:yBZ99NdGjYMFNrkMHHjImF3RBi4@dyp93ivlg

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const { v2: cloudinary } = require('cloudinary');
-cloudinary.config('cloudinary://523438194377183:yBZ99NdGjYMFNrkMHHjImF3RBi4@dyp93ivlg');
+cloudinary.config(process.env.CLOUDINARY_URL);
 
 const express = require("express");
 const multer = require("multer");
@@ -76,7 +76,7 @@ app.use("/api/users", usersRoutes);
 app.use("/api/floors", floorsRoutes);
 app.use("/api/rooms", roomsRoutes);
 app.use("/api/auth", authRoutes);
-app.use('/api/bulles', upload.single('photo'), bullesRoutes);
+app.use('/api/bulles', bullesRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Serveur en ligne sur le port ${PORT}`));


### PR DESCRIPTION
## Summary
- add `CLOUDINARY_URL` variable to `.env`
- configure `server.js` to use `process.env.CLOUDINARY_URL`
- remove upload middleware from route registration

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f0a63ac88327b0811e2bc21c7039