### PR TITLE
Fix CSV export for bulles

### DIFF
--- a/routes/bulles.js
+++ b/routes/bulles.js
@@ -198,14 +198,8 @@ router.get("/export/csv", async (req, res) => {
       );
     }
 
-    // Convertir chemins photo en URL complètes (exemple ici : base URL à adapter)
-    const baseUrl = req.protocol + "://" + req.get("host");
-    const rowsWithFullPhoto = result.rows.map(row => {
-      return {
-        ...row,
-        photo: row.photo ? `=IMAGE("${baseUrl}${row.photo}")` : ""
-      };
-    });
+    // Les URLs Cloudinary sont déjà complètes
+    const rowsWithFullPhoto = result.rows;
 
     const fields = [
       "etage",


### PR DESCRIPTION
## Summary
- export usernames instead of ids for `created_by`/`modified_by`
- output photo URL directly (no IMAGE formula)

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f52bdab0832780f7688fc460c19f