### PR TITLE
Use userId for creating and updating bulles

### DIFF
--- a/routes/bulles.js
+++ b/routes/bulles.js
@@ -26,10 +26,9 @@ router.post("/", /* isAuthenticated, */ upload.single("photo"), async (req, res)
   try {
     const {
       etage, chambre, x, y, numero, description,
-      intitule, etat, lot, entreprise, localisation, observation, date_butoir
+      intitule, etat, lot, entreprise, localisation, observation, date_butoir,
+      userId
     } = req.body;
-
-    const userId = null; // Pas de session user
 
     const safeDate = date_butoir === "" ? null : date_butoir;
     const photo = req.file ? req.file.path : null;
@@ -79,10 +78,9 @@ router.put("/:id", /* isAuthenticated, */ upload.single("photo"), async (req, re
   try {
     const { id } = req.params;
     const {
-      description, intitule, etat, lot, entreprise, localisation, observation, date_butoir
+      description, intitule, etat, lot, entreprise, localisation, observation, date_butoir,
+      userId
     } = req.body;
-
-    const userId = null; // Pas d'utilisateur connecté
 
     const safeDate = date_butoir === "" ? null : date_butoir;
     const photo = req.file ? req.file.path : null;


### PR DESCRIPTION
## Summary
- pull `userId` from request body in bulle creation and update
- store that user id in `created_by`, `modified_by` and history tables

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686633a2a87c8327990c8a24635f1492