### PR TITLE
Ajout filtres étage et lot dans l'historique

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -53,6 +53,31 @@
         <select id="task-select"><option value="">--D'abord choisir un lot--</option></select>
       </label>
       <button id="submit-selection">Valider</button>
+      <label>Filtrer par étage :
+        <select id="filter-floor">
+          <option value="">Tous</option>
+          <option value="R+0">R+0</option>
+          <option value="R+1">R+1</option>
+          <option value="R+2">R+2</option>
+          <option value="R+3">R+3</option>
+          <option value="R+4">R+4</option>
+          <option value="R+5">R+5</option>
+        </select>
+      </label>
+      <label>Filtrer par lot :
+        <select id="filter-lot">
+          <option value="">Tous</option>
+          <option value="DEPOSE">DEPOSE</option>
+          <option value="Platrerie">Plâtrerie</option>
+          <option value="Electricite">Électricité</option>
+          <option value="Plomberie">Plomberie</option>
+          <option value="Menuiserie">Menuiserie</option>
+          <option value="Revêtement SDB">Revêtement SDB</option>
+          <option value="Peinture">Peinture</option>
+          <option value="Revêtement de sol">Revêtement de sol</option>
+          <option value="Repose">Repose</option>
+        </select>
+      </label>
       <h2>Historique des interventions</h2>
       <div class="export-buttons">
         <button id="export-csv">Export CSV</button>

--- a/public/selection.js
+++ b/public/selection.js
@@ -45,6 +45,8 @@ const lotSelect   = document.getElementById('lot-select');
 const taskSelect  = document.getElementById('task-select');
 const statusSelect = document.getElementById('status-select');
 const submitBtn   = document.getElementById('submit-selection');
+const filterFloor = document.getElementById('filter-floor');
+const filterLot   = document.getElementById('filter-lot');
 const statusLabels = {
   ouvert: 'Ouvert',
   en_cours: 'En cours',
@@ -57,7 +59,10 @@ let editId = null;
 
 async function loadInterventions() {
   console.log('Appel loadInterventions');
-  const res = await fetch('/api/interventions');
+  let url = '/api/interventions?';
+  if (filterFloor.value) url += `floorId=${encodeURIComponent(filterFloor.value)}&`;
+  if (filterLot.value)   url += `lot=${encodeURIComponent(filterLot.value)}&`;
+  const res = await fetch(url);
   console.log('GET /api/interventions status:', res.status);
   if (!res.ok) {
     console.error('Erreur fetch historique', res.status);
@@ -131,6 +136,9 @@ lotSelect.addEventListener('change', () => {
     taskSelect.innerHTML = tasks.map(t => `<option value="${t}">${t}</option>`).join('');
   }
 });
+
+filterFloor.addEventListener('change', loadInterventions);
+filterLot  .addEventListener('change', loadInterventions);
 
 document.getElementById('interventions-table').addEventListener('click', async (e) => {
   if (e.target.classList.contains('edit-btn')) {

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -61,9 +61,23 @@ router.post('/', async (req, res) => {
 
 // GET /api/interventions — liste toutes les interventions
 router.get('/', async (req, res) => {
-  const { rows } = await pool.query(
-    'SELECT id, user_id, floor_id, room_id, lot, task, status, created_at FROM interventions ORDER BY created_at DESC'
-  );
+  const { floorId, lot } = req.query;
+  let query = 'SELECT id, user_id, floor_id, room_id, lot, task, status, created_at FROM interventions';
+  const params = [];
+  const conditions = [];
+  if (floorId) {
+    params.push(floorId);
+    conditions.push(`floor_id = $${params.length}`);
+  }
+  if (lot) {
+    params.push(lot);
+    conditions.push(`lot = $${params.length}`);
+  }
+  if (conditions.length) {
+    query += ' WHERE ' + conditions.join(' AND ');
+  }
+  query += ' ORDER BY created_at DESC';
+  const { rows } = await pool.query(query, params);
   res.json(rows);
 });
 


### PR DESCRIPTION
## Summary
- ajoute deux sélecteurs de filtre au-dessus de l'historique
- met à jour le script front pour les utiliser lors du fetch
- adapte la route GET /api/interventions pour filtrer suivant `floorId` et `lot`

## Testing
- `npm run start` *(échoue : module 'cloudinary' manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6866382088108327bd07f4c3637f59fd