### PR TITLE
Add filters to history page

### DIFF
--- a/public/historique.html
+++ b/public/historique.html
@@ -10,6 +10,32 @@
   <header>
     <h1>Historique des actions</h1>
     <button id="backBtn">Retour</button>
+    <label>Étage :
+      <select id="filter-etage">
+        <option value="">-- Tous --</option>
+        <option value="R+5">R+5</option>
+        <option value="R+4">R+4</option>
+        <option value="R+3">R+3</option>
+        <option value="R+2">R+2</option>
+        <option value="R+1">R+1</option>
+        <option value="R+0">R+0</option>
+      </select>
+    </label>
+    <label>Lot :
+      <select id="filter-lot">
+        <option value="">-- Tous --</option>
+        <option value="DEPOSE">DEPOSE</option>
+        <option value="Platrerie">Plâtrerie</option>
+        <option value="Electricite">Électricité</option>
+        <option value="Plomberie">Plomberie</option>
+        <option value="Menuiserie">Menuiserie</option>
+        <option value="Revêtement SDB">Revêtement SDB</option>
+        <option value="Peinture">Peinture</option>
+        <option value="Revêtement de sol">Revêtement de sol</option>
+        <option value="Repose">Repose</option>
+      </select>
+    </label>
+    <button id="apply-filters">Afficher</button>
   </header>
   <main id="tableWrapper">
     <table id="historyTable">

--- a/public/historique.js
+++ b/public/historique.js
@@ -2,15 +2,28 @@ window.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
   const actions = JSON.parse(localStorage.getItem('actions') || '[]');
 
-  if (actions.length === 0) {
-    const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 6;
-    cell.textContent = 'Aucune action enregistrée.';
-    row.appendChild(cell);
-    tbody.appendChild(row);
-  } else {
-    actions.forEach(a => {
+  function loadHistory() {
+    const filterEtage = document.getElementById('filter-etage').value;
+    const filterLot = document.getElementById('filter-lot').value;
+
+    const filtered = actions.filter(a =>
+      (!filterEtage || a.etage === filterEtage) &&
+      (!filterLot || a.lot === filterLot)
+    );
+
+    tbody.innerHTML = '';
+
+    if (filtered.length === 0) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.textContent = 'Aucune action enregistrée.';
+      row.appendChild(cell);
+      tbody.appendChild(row);
+      return;
+    }
+
+    filtered.forEach(a => {
       const row = document.createElement('tr');
 
       const emplacement = a.chambre
@@ -25,7 +38,7 @@ window.addEventListener('DOMContentLoaded', () => {
         a.description || '',
         new Date(a.timestamp).toLocaleString()
       ];
-      values.forEach((val, idx) => {
+      values.forEach(val => {
         const td = document.createElement('td');
         td.textContent = val;
         row.appendChild(td);
@@ -33,6 +46,10 @@ window.addEventListener('DOMContentLoaded', () => {
       tbody.appendChild(row);
     });
   }
+
+  loadHistory();
+
+  document.getElementById('apply-filters').addEventListener('click', loadHistory);
 
   document.getElementById('backBtn').addEventListener('click', () => {
     window.location.href = 'index.html';


### PR DESCRIPTION
## Summary
- add Etage/Lot filters and button in historique page
- display only matching actions from localStorage when filters applied

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686684a3be9c8327a6e966d69beb1e68