### PR TITLE
Use API for history page

### DIFF
--- a/public/historique.html
+++ b/public/historique.html
@@ -45,6 +45,7 @@
           <th>Action</th>
           <th>Emplacement</th>
           <th>Bulle</th>
+          <th>Lot</th>
           <th>Description</th>
           <th>Date/Heure</th>
         </tr>


### PR DESCRIPTION
## Summary
- add Lot column in history table
- load history from `/api/history` and filter client-side

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68678371e840832790f6db09e43451ed