### PR TITLE
Fix /api/history endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const interventionsRoutes = require("./routes/interventions");
 const usersRoutes = require("./routes/users");
 const floorsRoutes = require("./routes/floors");
 const roomsRoutes = require("./routes/rooms");
+const historyRoutes = require("./routes/history");
 const pool = require("./db");
 
 (async () => {
@@ -77,6 +78,7 @@ app.use("/api/floors", floorsRoutes);
 app.use("/api/rooms", roomsRoutes);
 app.use("/api/auth", authRoutes);
 app.use('/api/bulles', bullesRoutes);
+app.use('/api/history', historyRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Serveur en ligne sur le port ${PORT}`));


### PR DESCRIPTION
## Summary
- wire up history route under `/api/history`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68678eb192d88327ac46a057d2da97f1