### PR TITLE
Debug logs for history filter

### DIFF
--- a/public/historique.js
+++ b/public/historique.js
@@ -17,10 +17,16 @@ window.addEventListener('DOMContentLoaded', () => {
       console.error('Erreur chargement historique', err);
     }
 
-    const filtered = actions.filter(e =>
-      (!filterEtage || e.etage === filterEtage) &&
-      (!filterLot   || e.lot   === filterLot)
-    );
+    const filtered = actions.filter(e => {
+      const matchEtage = !filterEtage || e.etage === filterEtage;
+      const matchLot   = !filterLot
+        || (e.lot || '').toLowerCase() === filterLot.toLowerCase();
+      return matchEtage && matchLot;
+    });
+
+    console.log('Filtres:', { filterEtage, filterLot });
+    console.log('Actions brutes:', actions);
+    console.log('Actions filtrées:', filtered);
 
     tbody.innerHTML = '';
 


### PR DESCRIPTION
## Summary
- add detailed logs in `loadHistory()` for debugging
- make lot filtering case insensitive

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686797f845a083279ab89a3780c4310e