### PR TITLE
Display lot in history and add filtering

### DIFF
--- a/public/historique.css
+++ b/public/historique.css
@@ -13,6 +13,11 @@ header {
   margin-bottom: 20px;
 }
 
+.filters {
+  display: flex;
+  gap: 10px;
+}
+
 h1 {
   margin: 0;
   font-size: 24px;

--- a/public/historique.html
+++ b/public/historique.html
@@ -9,6 +9,14 @@
 <body>
   <header>
     <h1>Historique des actions</h1>
+    <div class="filters">
+      <label>Étage :
+        <select id="floorFilter"></select>
+      </label>
+      <label>Lot :
+        <select id="lotFilter"></select>
+      </label>
+    </div>
     <button id="backBtn">Retour</button>
   </header>
   <main id="tableWrapper">
@@ -19,6 +27,7 @@
           <th>Action</th>
           <th>Emplacement</th>
           <th>Bulle</th>
+          <th>Lot</th>
           <th>Description</th>
           <th>Date/Heure</th>
         </tr>

--- a/public/historique.js
+++ b/public/historique.js
@@ -1,31 +1,48 @@
 window.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
+  const floorFilter = document.getElementById('floorFilter');
+  const lotFilter = document.getElementById('lotFilter');
   const actions = JSON.parse(localStorage.getItem('actions') || '[]');
 
-  if (actions.length === 0) {
-    const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 6;
-    cell.textContent = 'Aucune action enregistrée.';
-    row.appendChild(cell);
-    tbody.appendChild(row);
-  } else {
-    actions.forEach(a => {
-      const row = document.createElement('tr');
+  const floors = [...new Set(actions.map(a => a.etage))];
+  const lots = [...new Set(actions.map(a => a.lot).filter(l => l))];
 
+  floorFilter.innerHTML = ['<option value="">Tous</option>']
+    .concat(floors.map(f => `<option value="${f}">${f}</option>`)).join('');
+  lotFilter.innerHTML = ['<option value="">Tous</option>']
+    .concat(lots.map(l => `<option value="${l}">${l}</option>`)).join('');
+
+  function render() {
+    tbody.innerHTML = '';
+    let filtered = actions.slice();
+    if (floorFilter.value) filtered = filtered.filter(a => a.etage === floorFilter.value);
+    if (lotFilter.value) filtered = filtered.filter(a => a.lot === lotFilter.value);
+
+    if (filtered.length === 0) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 7;
+      cell.textContent = 'Aucune action enregistrée.';
+      row.appendChild(cell);
+      tbody.appendChild(row);
+      return;
+    }
+
+    filtered.forEach(a => {
+      const row = document.createElement('tr');
       const emplacement = a.chambre
         ? `${a.etage} / ${a.chambre}`
         : `${a.etage} (${Number(a.x).toFixed(2)}, ${Number(a.y).toFixed(2)})`;
-
       const values = [
         a.user,
         a.action,
         emplacement,
         a.nomBulle || '',
+        a.lot || '',
         a.description || '',
         new Date(a.timestamp).toLocaleString()
       ];
-      values.forEach((val, idx) => {
+      values.forEach(val => {
         const td = document.createElement('td');
         td.textContent = val;
         row.appendChild(td);
@@ -33,6 +50,10 @@ window.addEventListener('DOMContentLoaded', () => {
       tbody.appendChild(row);
     });
   }
+
+  render();
+  floorFilter.addEventListener('change', render);
+  lotFilter.addEventListener('change', render);
 
   document.getElementById('backBtn').addEventListener('click', () => {
     window.location.href = 'index.html';

--- a/public/script.js
+++ b/public/script.js
@@ -164,7 +164,17 @@
       const encodedName = encodeURIComponent(bulle.intitule || '');
       const encodedDesc = encodeURIComponent(bulle.description || '');
       deleteBtn.onclick = () => {
-        confirmDelete(bulle.id, bulle.etage, bulle.chambre, div.dataset.x, div.dataset.y, bulle.numero, encodedName, encodedDesc);
+        confirmDelete(
+          bulle.id,
+          bulle.etage,
+          bulle.chambre,
+          div.dataset.x,
+          div.dataset.y,
+          bulle.numero,
+          encodedName,
+          encodedDesc,
+          bulle.lot
+        );
       };
 
       form.onsubmit = (e) => {
@@ -189,6 +199,7 @@
               x: div.dataset.x,
               y: div.dataset.y,
               nomBulle,
+              lot: formData.get('lot') || '',
               description: desc
             });
             closePopups();
@@ -272,7 +283,7 @@
       p.remove();
     });
   }
-  function confirmDelete(id, etage, chambre, x, y, numero, encName, encDesc) {
+  function confirmDelete(id, etage, chambre, x, y, numero, encName, encDesc, lot) {
     if (!user) {
       alert("Vous devez être connecté pour supprimer.");
       return;
@@ -280,14 +291,14 @@
     if (confirm("Voulez-vous vraiment supprimer cette bulle ?")) {
       const name = decodeURIComponent(encName || '');
       const desc = decodeURIComponent(encDesc || '');
-      deleteBulle(id, etage, chambre, x, y, numero, name, desc);
+      deleteBulle(id, etage, chambre, x, y, numero, name, desc, lot);
     }
   }
-  function deleteBulle(id, etage, chambre, x, y, numero, name, desc) {
+  function deleteBulle(id, etage, chambre, x, y, numero, name, desc, lot) {
     fetch(`/api/bulles/${id}`, { method: "DELETE", credentials: "include" }).then(() => {
       loadBulles();
       const nomBulle = name ? `Bulle ${numero}, ${name}` : `Bulle ${numero}`;
-      recordAction("suppression", { etage, chambre, x, y, nomBulle, description: desc });
+      recordAction("suppression", { etage, chambre, x, y, nomBulle, lot, description: desc });
     });
   }
   function zoomImage(src) {
@@ -314,6 +325,7 @@
       x: loc.x,
       y: loc.y,
       nomBulle: loc.nomBulle || '',
+      lot: loc.lot || '',
       description: loc.description || '',
       timestamp: new Date().toISOString()
     };
@@ -461,6 +473,7 @@
           x: xRatio,
           y: yRatio,
           nomBulle,
+          lot: formData.get('lot') || '',
           description: desc
         });
         closePopups();


### PR DESCRIPTION
## Summary
- show lot information in the history table
- record lot data on bubble creation, edition and deletion
- allow filtering history by floor and lot
- minor styling tweaks for filter selectors

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867f0fb51d4832791763a1c39a4dcc2