### PR TITLE
Fix history table to load from API

### DIFF
--- a/public/historique.css
+++ b/public/historique.css
@@ -13,6 +13,11 @@ header {
   margin-bottom: 20px;
 }
 
+.filters {
+  display: flex;
+  gap: 10px;
+}
+
 h1 {
   margin: 0;
   font-size: 24px;

--- a/public/historique.html
+++ b/public/historique.html
@@ -9,6 +9,14 @@
 <body>
   <header>
     <h1>Historique des actions</h1>
+    <div class="filters">
+      <label>Étage :
+        <select id="floorFilter"></select>
+      </label>
+      <label>Lot :
+        <select id="lotFilter"></select>
+      </label>
+    </div>
     <button id="backBtn">Retour</button>
   </header>
   <main id="tableWrapper">
@@ -19,6 +27,7 @@
           <th>Action</th>
           <th>Emplacement</th>
           <th>Bulle</th>
+          <th>Lot</th>
           <th>Description</th>
           <th>Date/Heure</th>
         </tr>

--- a/public/historique.js
+++ b/public/historique.js
@@ -1,31 +1,48 @@
 window.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
+  const floorFilter = document.getElementById('floorFilter');
+  const lotFilter = document.getElementById('lotFilter');
   const actions = JSON.parse(localStorage.getItem('actions') || '[]');
 
-  if (actions.length === 0) {
-    const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 6;
-    cell.textContent = 'Aucune action enregistrée.';
-    row.appendChild(cell);
-    tbody.appendChild(row);
-  } else {
-    actions.forEach(a => {
-      const row = document.createElement('tr');
+  const floors = [...new Set(actions.map(a => a.etage))];
+  const lots = [...new Set(actions.map(a => a.lot).filter(l => l))];
 
+  floorFilter.innerHTML = ['<option value="">Tous</option>']
+    .concat(floors.map(f => `<option value="${f}">${f}</option>`)).join('');
+  lotFilter.innerHTML = ['<option value="">Tous</option>']
+    .concat(lots.map(l => `<option value="${l}">${l}</option>`)).join('');
+
+  function render() {
+    tbody.innerHTML = '';
+    let filtered = actions.slice();
+    if (floorFilter.value) filtered = filtered.filter(a => a.etage === floorFilter.value);
+    if (lotFilter.value) filtered = filtered.filter(a => a.lot === lotFilter.value);
+
+    if (filtered.length === 0) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 7;
+      cell.textContent = 'Aucune action enregistrée.';
+      row.appendChild(cell);
+      tbody.appendChild(row);
+      return;
+    }
+
+    filtered.forEach(a => {
+      const row = document.createElement('tr');
       const emplacement = a.chambre
         ? `${a.etage} / ${a.chambre}`
         : `${a.etage} (${Number(a.x).toFixed(2)}, ${Number(a.y).toFixed(2)})`;
-
       const values = [
         a.user,
         a.action,
         emplacement,
         a.nomBulle || '',
+        a.lot || '',
         a.description || '',
         new Date(a.timestamp).toLocaleString()
       ];
-      values.forEach((val, idx) => {
+      values.forEach(val => {
         const td = document.createElement('td');
         td.textContent = val;
         row.appendChild(td);
@@ -33,6 +50,10 @@ window.addEventListener('DOMContentLoaded', () => {
       tbody.appendChild(row);
     });
   }
+
+  render();
+  floorFilter.addEventListener('change', render);
+  lotFilter.addEventListener('change', render);
 
   document.getElementById('backBtn').addEventListener('click', () => {
     window.location.href = 'index.html';

--- a/public/historique.js
+++ b/public/historique.js
@@ -1,22 +1,38 @@
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('DOMContentLoaded', async () => {
   const tbody = document.querySelector('#historyTable tbody');
   const floorFilter = document.getElementById('floorFilter');
   const lotFilter = document.getElementById('lotFilter');
-  const actions = JSON.parse(localStorage.getItem('actions') || '[]');
+  let actions = [];
 
-  const floors = [...new Set(actions.map(a => a.etage))];
-  const lots = [...new Set(actions.map(a => a.lot).filter(l => l))];
+  async function loadActions() {
+    const res = await fetch('/api/history');
+    actions = await res.json();
+    actions.forEach(a => {
+      if (a.new_values && typeof a.new_values === 'string') {
+        try { a.new_values = JSON.parse(a.new_values); } catch (e) {}
+      }
+      if (a.old_values && typeof a.old_values === 'string') {
+        try { a.old_values = JSON.parse(a.old_values); } catch (e) {}
+      }
+    });
 
-  floorFilter.innerHTML = ['<option value="">Tous</option>']
-    .concat(floors.map(f => `<option value="${f}">${f}</option>`)).join('');
-  lotFilter.innerHTML = ['<option value="">Tous</option>']
-    .concat(lots.map(l => `<option value="${l}">${l}</option>`)).join('');
+    const floors = [...new Set(actions.map(a => a.etage).filter(Boolean))];
+    const lots = [...new Set(actions.map(a => (a.new_values?.lot || a.old_values?.lot || a.lot)).filter(Boolean))];
+
+    floorFilter.innerHTML = ['<option value="">Tous</option>']
+      .concat(floors.map(f => `<option value="${f}">${f}</option>`)).join('');
+    lotFilter.innerHTML = ['<option value="">Tous</option>']
+      .concat(lots.map(l => `<option value="${l}">${l}</option>`)).join('');
+  }
 
   function render() {
     tbody.innerHTML = '';
     let filtered = actions.slice();
     if (floorFilter.value) filtered = filtered.filter(a => a.etage === floorFilter.value);
-    if (lotFilter.value) filtered = filtered.filter(a => a.lot === lotFilter.value);
+    if (lotFilter.value) filtered = filtered.filter(a => {
+      const lot = a.new_values?.lot || a.old_values?.lot || a.lot;
+      return lot === lotFilter.value;
+    });
 
     if (filtered.length === 0) {
       const row = document.createElement('tr');
@@ -30,17 +46,24 @@ window.addEventListener('DOMContentLoaded', () => {
 
     filtered.forEach(a => {
       const row = document.createElement('tr');
+      const data = a.new_values || a.old_values || {};
       const emplacement = a.chambre
         ? `${a.etage} / ${a.chambre}`
-        : `${a.etage} (${Number(a.x).toFixed(2)}, ${Number(a.y).toFixed(2)})`;
+        : `${a.etage} (${Number(data.x || 0).toFixed(2)}, ${Number(data.y || 0).toFixed(2)})`;
+      const nomBulle = data.intitule ? `Bulle ${a.bulle_numero}, ${data.intitule}` : `Bulle ${a.bulle_numero}`;
+      const lot = data.lot || a.lot || '';
+      const description = data.description || '';
+      const actionText = a.action_type === 'create' ? 'creation'
+                        : a.action_type === 'update' ? 'modification'
+                        : a.action_type;
       const values = [
-        a.user,
-        a.action,
+        a.username || '',
+        actionText,
         emplacement,
-        a.nomBulle || '',
-        a.lot || '',
-        a.description || '',
-        new Date(a.timestamp).toLocaleString()
+        nomBulle,
+        lot,
+        description,
+        new Date(a.created_at).toLocaleString()
       ];
       values.forEach(val => {
         const td = document.createElement('td');
@@ -51,6 +74,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  await loadActions();
   render();
   floorFilter.addEventListener('change', render);
   lotFilter.addEventListener('change', render);

--- a/public/script.js
+++ b/public/script.js
@@ -164,7 +164,17 @@
       const encodedName = encodeURIComponent(bulle.intitule || '');
       const encodedDesc = encodeURIComponent(bulle.description || '');
       deleteBtn.onclick = () => {
-        confirmDelete(bulle.id, bulle.etage, bulle.chambre, div.dataset.x, div.dataset.y, bulle.numero, encodedName, encodedDesc);
+        confirmDelete(
+          bulle.id,
+          bulle.etage,
+          bulle.chambre,
+          div.dataset.x,
+          div.dataset.y,
+          bulle.numero,
+          encodedName,
+          encodedDesc,
+          bulle.lot
+        );
       };
 
       form.onsubmit = (e) => {
@@ -189,6 +199,7 @@
               x: div.dataset.x,
               y: div.dataset.y,
               nomBulle,
+              lot: formData.get('lot') || '',
               description: desc
             });
             closePopups();
@@ -272,7 +283,7 @@
       p.remove();
     });
   }
-  function confirmDelete(id, etage, chambre, x, y, numero, encName, encDesc) {
+  function confirmDelete(id, etage, chambre, x, y, numero, encName, encDesc, lot) {
     if (!user) {
       alert("Vous devez être connecté pour supprimer.");
       return;
@@ -280,14 +291,14 @@
     if (confirm("Voulez-vous vraiment supprimer cette bulle ?")) {
       const name = decodeURIComponent(encName || '');
       const desc = decodeURIComponent(encDesc || '');
-      deleteBulle(id, etage, chambre, x, y, numero, name, desc);
+      deleteBulle(id, etage, chambre, x, y, numero, name, desc, lot);
     }
   }
-  function deleteBulle(id, etage, chambre, x, y, numero, name, desc) {
+  function deleteBulle(id, etage, chambre, x, y, numero, name, desc, lot) {
     fetch(`/api/bulles/${id}`, { method: "DELETE", credentials: "include" }).then(() => {
       loadBulles();
       const nomBulle = name ? `Bulle ${numero}, ${name}` : `Bulle ${numero}`;
-      recordAction("suppression", { etage, chambre, x, y, nomBulle, description: desc });
+      recordAction("suppression", { etage, chambre, x, y, nomBulle, lot, description: desc });
     });
   }
   function zoomImage(src) {
@@ -314,6 +325,7 @@
       x: loc.x,
       y: loc.y,
       nomBulle: loc.nomBulle || '',
+      lot: loc.lot || '',
       description: loc.description || '',
       timestamp: new Date().toISOString()
     };
@@ -461,6 +473,7 @@
           x: xRatio,
           y: yRatio,
           nomBulle,
+          lot: formData.get('lot') || '',
           description: desc
         });
         closePopups();

--- a/routes/history.js
+++ b/routes/history.js
@@ -1,0 +1,34 @@
+const router = require('express').Router();
+const pool = require('../db');
+
+router.get('/', async (req, res) => {
+  const { etage, lot } = req.query;
+  const params = [];
+  let idx = 1;
+  let where = '1=1';
+  if (etage) {
+    where += ` AND b.etage = $${idx++}`;
+    params.push(etage);
+  }
+  if (lot) {
+    where += ` AND b.lot = $${idx++}`;
+    params.push(lot);
+  }
+  try {
+    const result = await pool.query(
+      `SELECT rh.*, u.username, b.etage, b.chambre, b.lot, b.numero AS bulle_numero
+       FROM reserve_history rh
+       JOIN bulles b ON b.id = rh.bulle_id
+       JOIN users u ON u.id = rh.user_id
+       WHERE ${where}
+       ORDER BY rh.created_at DESC`,
+      params
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur historique' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const interventionsRoutes = require("./routes/interventions");
 const usersRoutes = require("./routes/users");
 const floorsRoutes = require("./routes/floors");
 const roomsRoutes = require("./routes/rooms");
+const historyRoutes = require("./routes/history");
 const pool = require("./db");
 
 (async () => {
@@ -77,6 +78,7 @@ app.use("/api/floors", floorsRoutes);
 app.use("/api/rooms", roomsRoutes);
 app.use("/api/auth", authRoutes);
 app.use('/api/bulles', bullesRoutes);
+app.use('/api/history', historyRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Serveur en ligne sur le port ${PORT}`));


### PR DESCRIPTION
## Summary
- add API route for history data
- fetch history from backend in `historique.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'cloudinary')*

------
https://chatgpt.com/codex/tasks/task_e_68691290d6108327ac6323c39dce41e7