### PR TITLE
Fix history page uses server data

### DIFF
--- a/public/historique.js
+++ b/public/historique.js
@@ -1,38 +1,53 @@
 window.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
-  const actions = JSON.parse(localStorage.getItem('actions') || '[]');
 
-  if (actions.length === 0) {
-    const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 6;
-    cell.textContent = 'Aucune action enregistrée.';
-    row.appendChild(cell);
-    tbody.appendChild(row);
-  } else {
-    actions.forEach(a => {
-      const row = document.createElement('tr');
+  fetch('/api/history')
+    .then(res => res.json())
+    .then(actions => {
+      if (!Array.isArray(actions) || actions.length === 0) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 6;
+        cell.textContent = 'Aucune action enregistrée.';
+        row.appendChild(cell);
+        tbody.appendChild(row);
+        return;
+      }
 
-      const emplacement = a.chambre
-        ? `${a.etage} / ${a.chambre}`
-        : `${a.etage} (${Number(a.x).toFixed(2)}, ${Number(a.y).toFixed(2)})`;
+      actions.forEach(a => {
+        const row = document.createElement('tr');
 
-      const values = [
-        a.user,
-        a.action,
-        emplacement,
-        a.nomBulle || '',
-        a.description || '',
-        new Date(a.timestamp).toLocaleString()
-      ];
-      values.forEach((val, idx) => {
-        const td = document.createElement('td');
-        td.textContent = val;
-        row.appendChild(td);
+        const emplacement = a.chambre
+          ? `${a.etage} / ${a.chambre}`
+          : `${a.etage}`;
+
+        const desc = (a.new_values && a.new_values.description) ||
+                     (a.old_values && a.old_values.description) || '';
+
+        const values = [
+          a.username,
+          a.action_type,
+          emplacement,
+          a.bulle_numero || '',
+          desc,
+          new Date(a.created_at).toLocaleString()
+        ];
+        values.forEach(val => {
+          const td = document.createElement('td');
+          td.textContent = val;
+          row.appendChild(td);
+        });
+        tbody.appendChild(row);
       });
+    })
+    .catch(() => {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.textContent = 'Erreur de chargement.';
+      row.appendChild(cell);
       tbody.appendChild(row);
     });
-  }
 
   document.getElementById('backBtn').addEventListener('click', () => {
     window.location.href = 'index.html';

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const storage = new CloudinaryStorage({
 });
 const upload = multer({ storage });
 const bullesRoutes = require("./routes/bulles");
+const historyRoutes = require("./routes/history");
 const authRoutes = require("./routes/auth");
 const interventionsRoutes = require("./routes/interventions");
 const usersRoutes = require("./routes/users");
@@ -77,6 +78,7 @@ app.use("/api/floors", floorsRoutes);
 app.use("/api/rooms", roomsRoutes);
 app.use("/api/auth", authRoutes);
 app.use('/api/bulles', bullesRoutes);
+app.use('/api/history', historyRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Serveur en ligne sur le port ${PORT}`));


### PR DESCRIPTION
## Summary
- provide API endpoint for history and use it in history page
- display server history instead of local data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a9bf76ca4832791b6870660d5d3cc