### PR TITLE
Add intervention history table and filtering

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -71,6 +71,26 @@
           </thead>
         <tbody></tbody>
       </table>
+      <label>Filtrer l'historique par lot :
+        <select id="history-lot-filter">
+          <option value="">Tous</option>
+        </select>
+      </label>
+      <table id="historyTable">
+        <thead>
+          <tr>
+            <th>Utilisateur</th>
+            <th>Action</th>
+            <th>Lot</th>
+            <th>Étage / Chambre</th>
+            <th>Tâche</th>
+            <th>Personne</th>
+            <th>État</th>
+            <th>Date/Heure</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
   </main>
   <script src="selection.js"></script>

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -67,6 +67,18 @@ router.get('/', async (req, res) => {
   res.json(rows);
 });
 
+router.get('/history', async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      'SELECT id, action_type, lot, etage, chambre, tache, personne, etat, created_at AS timestamp, user_id FROM intervention_history ORDER BY created_at DESC'
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Erreur historique" });
+  }
+});
+
 function escapePdf(str) {
   return String(str)
     .replace(/\\/g, "\\\\")


### PR DESCRIPTION
## Summary
- append a new history table in `selection.html`
- fetch history data and render with filtering in `selection.js`
- expose `/api/interventions/history` route to return intervention history

## Testing
- `node --check public/selection.js`
- `node --check routes/interventions.js`

------
https://chatgpt.com/codex/tasks/task_e_686aa86430448327a41b2f8ed6e94ab3