### PR TITLE
Clean up historic table and JS

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -61,16 +61,6 @@
       </table>
       <button id="submit-selection">Valider</button>
       <h2>Historique des interventions</h2>
-      <div class="export-buttons">
-        <button id="export-csv">Export CSV</button>
-        <button id="export-pdf">Export PDF</button>
-      </div>
-        <table id="interventions-table">
-          <thead>
-            <tr><th>ID</th><th>Employé</th><th>Étage</th><th>Chambre</th><th>Lot</th><th>Tâche</th><th>État</th><th>Date</th><th>Modifier</th><th>Supprimer</th></tr>
-          </thead>
-        <tbody></tbody>
-      </table>
       <label>Filtrer l'historique par lot :
         <select id="history-lot-filter">
           <option value="">Tous</option>

--- a/public/selection.js
+++ b/public/selection.js
@@ -56,7 +56,6 @@ let currentInterventions = [];
 let editId = null;
 const rowsByLot = {};
 let currentLot = '';
-let historyEntries = [];
 
 async function loadHistory() {
   try {
@@ -312,20 +311,10 @@ submitBtn.addEventListener('click', async () => {
   }
 });
 
-document.getElementById('export-csv').addEventListener('click', () => {
-  window.location.href = '/api/interventions/export/csv';
-});
-
-document.getElementById('export-pdf').addEventListener('click', () => {
-  window.location.href = '/api/interventions/export/pdf';
-});
-
 window.addEventListener('DOMContentLoaded', async () => {
   await loadUsers();
   await loadFloors();
   await loadInterventions();
-  await loadHistory();
-  document.getElementById('history-lot-filter').addEventListener('change', renderHistory);
   currentLot = lotSelect.value;
   rebuildTasksTable();
 });


### PR DESCRIPTION
## Summary
- remove old interventions table markup
- remove export and loadHistory hooks from selection page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686aabdc61b08327be0f36ea288d5328