### PR TITLE
Supprimer l’ancien tableau d’interventions

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -61,16 +61,6 @@
       </table>
       <button id="submit-selection">Valider</button>
       <h2>Historique des interventions</h2>
-      <div class="export-buttons">
-        <button id="export-csv">Export CSV</button>
-        <button id="export-pdf">Export PDF</button>
-      </div>
-        <table id="interventions-table">
-          <thead>
-            <tr><th>ID</th><th>Employé</th><th>Étage</th><th>Chambre</th><th>Lot</th><th>Tâche</th><th>État</th><th>Date</th><th>Modifier</th><th>Supprimer</th></tr>
-          </thead>
-        <tbody></tbody>
-      </table>
       <label>Filtrer l'historique par lot :
         <select id="history-lot-filter">
           <option value="">Tous</option>

--- a/public/selection.js
+++ b/public/selection.js
@@ -312,20 +312,11 @@ submitBtn.addEventListener('click', async () => {
   }
 });
 
-document.getElementById('export-csv').addEventListener('click', () => {
-  window.location.href = '/api/interventions/export/csv';
-});
-
-document.getElementById('export-pdf').addEventListener('click', () => {
-  window.location.href = '/api/interventions/export/pdf';
-});
 
 window.addEventListener('DOMContentLoaded', async () => {
   await loadUsers();
   await loadFloors();
   await loadInterventions();
-  await loadHistory();
-  document.getElementById('history-lot-filter').addEventListener('change', renderHistory);
   currentLot = lotSelect.value;
   rebuildTasksTable();
 });


### PR DESCRIPTION
## Summary
- clean up `selection.html` by removing unused export buttons and the obsolete interventions table
- drop the related CSV/PDF export handlers and `loadHistory()` call in `selection.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aaeed5c6c8327a34884a2de0202b2