### PR TITLE
Fix Gestion des tâches person dropdown

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -138,10 +138,21 @@ async function loadInterventions() {
 }
 
 async function loadUsers() {
-  const res = await fetch('/api/users');
-  const users = await res.json();
-  window.userMap = users.reduce((m, u) => (m[u.id] = u.username, m), {});
-  // 1) Statisme la liste des personnes
+  let users = [];
+  try {
+    const res = await fetch('/api/users');
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    users = await res.json();
+  } catch (err) {
+    console.error('Erreur chargement utilisateurs', err);
+  }
+
+  window.userMap = users.reduce((m, u) => {
+    m[u.id] = u.username;
+    return m;
+  }, {});
+
+  // Liste statique des personnes à afficher dans le menu déroulant
   userSelect.innerHTML = [
     '<option value="">-- Choisir une personne --</option>',
     '<option value="ATHARI">ATHARI Keivan</option>',


### PR DESCRIPTION
## Summary
- avoid failing if `/api/users` cannot be fetched
- always set the people list in the dropdown

## Testing
- `npm start` *(fails: Cannot find module 'cloudinary')*

------
https://chatgpt.com/codex/tasks/task_e_686abedfe4d88327b95fd47a427473aa