### PR TITLE
Refactor tasks management UI

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -10,16 +10,6 @@
   <main class="container">
     <h1>Gestion tâche</h1>
     <div class="form-grid">
-      <label>État :
-        <select id="status-select">
-          <option value="">--Choisir un état--</option>
-          <option value="ouvert">Ouvert</option>
-          <option value="en_cours">En cours</option>
-          <option value="attente_validation">En attente de validation</option>
-          <option value="clos">Clos</option>
-          <option value="valide">Validé</option>
-        </select>
-      </label>
       <label>Étage :
         <select id="floor-select">
           <option value="">-- Choisir un étage --</option>
@@ -49,9 +39,26 @@
           <option value="Repose">Repose</option>
         </select>
       </label>
-      <label>Tâche :
-        <select id="task-select"><option value="">--D'abord choisir un lot--</option></select>
-      </label>
+      <table id="tasksTable">
+        <thead>
+          <tr>
+            <th>Tâche</th>
+            <th>Personne</th>
+            <th>État</th>
+            <th>Dernière modif</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><select id="task-select"></select></td>
+            <td><select></select></td>
+            <td>à définir</td>
+            <td>–</td>
+            <td><button type="button" class="add-row">＋</button></td>
+          </tr>
+        </tbody>
+      </table>
       <button id="submit-selection">Valider</button>
       <h2>Historique des interventions</h2>
       <div class="export-buttons">

--- a/public/selection.js
+++ b/public/selection.js
@@ -43,7 +43,7 @@ const floorSelect = document.getElementById('floor-select');
 const roomSelect  = document.getElementById('room-select');
 const lotSelect   = document.getElementById('lot-select');
 const taskSelect  = document.getElementById('task-select');
-const statusSelect = document.getElementById('status-select');
+const statusSelect = { value: 'a_definir' };
 const submitBtn   = document.getElementById('submit-selection');
 const statusLabels = {
   ouvert: 'Ouvert',
@@ -119,17 +119,63 @@ async function loadRooms(floorId) {
     rooms.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
 }
 
+// Reconstruit le tbody de #tasksTable pour le lot sélectionné
+function rebuildTasksTable() {
+  const lot = lotSelect.value;
+  const tasks = lotTasks[lot] || [];
+  const tbody = document.querySelector("#tasksTable tbody");
+  tbody.innerHTML = "";
+
+  // Crée une ligne vierge
+  addTaskRow(tbody, tasks);
+}
+
+// Ajoute une ligne dans le <tbody>
+function addTaskRow(tbody, tasks) {
+  const row = document.createElement("tr");
+  // Colonne Tâche : select options=tasks
+  const tdTask = document.createElement("td");
+  const selT = document.createElement("select");
+  if (!document.getElementById('task-select')) {
+    selT.id = 'task-select';
+  }
+  selT.innerHTML = `<option value="">-- Choisir tâche --</option>`
+    + tasks.map(t => `<option value="${t}">${t}</option>`).join("");
+  tdTask.appendChild(selT);
+  row.appendChild(tdTask);
+
+  // Colonne Personne : reutilise userSelect global
+  const tdUser = document.createElement("td");
+  const selU = document.createElement("select");
+  // on clone les options de userSelect
+  selU.innerHTML = userSelect.innerHTML;
+  tdUser.appendChild(selU);
+  row.appendChild(tdUser);
+
+  // Colonne État
+  const tdEtat = document.createElement("td");
+  tdEtat.textContent = "à définir";
+  row.appendChild(tdEtat);
+
+  // Colonne Dernière modif
+  const tdModif = document.createElement("td");
+  tdModif.textContent = "–";
+  row.appendChild(tdModif);
+
+  // Colonne Actions (+ / –)
+  const tdActions = document.createElement("td");
+  const btnAdd = document.createElement("button");
+  btnAdd.type = "button";
+  btnAdd.textContent = "＋";
+  btnAdd.addEventListener("click", () => addTaskRow(tbody, tasks));
+  tdActions.appendChild(btnAdd);
+  row.appendChild(tdActions);
+
+  tbody.appendChild(row);
+}
+
 floorSelect.addEventListener('change', () => {
   loadRooms(floorSelect.value);
-});
-
-lotSelect.addEventListener('change', () => {
-  const tasks = lotTasks[lotSelect.value] || [];
-  if (tasks.length === 0) {
-    taskSelect.innerHTML = '<option value="">--D\'abord choisir un lot--</option>';
-  } else {
-    taskSelect.innerHTML = tasks.map(t => `<option value="${t}">${t}</option>`).join('');
-  }
 });
 
 document.getElementById('interventions-table').addEventListener('click', async (e) => {
@@ -192,4 +238,8 @@ window.addEventListener('DOMContentLoaded', async () => {
   await loadUsers();
   await loadFloors();
   await loadInterventions();
+  lotSelect.addEventListener("change", () => {
+    rebuildTasksTable();
+  });
+  rebuildTasksTable();
 });


### PR DESCRIPTION
## Summary
- remove status select from task page
- introduce tasks table scaffold
- rebuild tasks table dynamically when lot changes
- initialize table on page load

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686acceee65c8327a81a852efcda99a3