### PR TITLE
Fix history route SQL comparison casting

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -148,9 +148,9 @@ router.get('/history', async (req, res) => {
             i.lot, i.task, i.status AS state, i.created_at AS date, i.person AS person
      FROM interventions i
      JOIN users u ON u.id = i.user_id
-     WHERE ($1 = '' OR i.floor_id = $1::int)
-       AND ($2 = '' OR i.room_id = $2::int)
-       AND ($3 = '' OR i.lot = $3)
+     WHERE ($1::text = '' OR i.floor_id = $1::int)
+       AND ($2::text = '' OR i.room_id = $2::int)
+       AND ($3::text = '' OR i.lot = $3::text)
      ORDER BY i.created_at DESC`,
     [etage, chambre, lot]
   );


### PR DESCRIPTION
## Summary
- ensure parameters in `/history` SQL query are compared as text first, then cast to `int`
- prevents `integer = text` comparison errors

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686bc0fd9e4883279e6f015bed8bc5b9