### PR TITLE
Fix filtering in history query

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -148,9 +148,9 @@ router.get('/history', async (req, res) => {
             i.lot, i.task, i.status AS state, i.created_at AS date, i.person AS person
      FROM interventions i
      JOIN users u ON u.id = i.user_id
-     WHERE ($1::text = '' OR i.floor_id = $1::int)
-       AND ($2::text = '' OR i.room_id = $2::int)
-       AND ($3::text = '' OR i.lot = $3::text)
+     WHERE ($1 = '' OR i.floor_id::text = $1)
+       AND ($2 = '' OR i.room_id::text = $2)
+       AND ($3 = '' OR i.lot::text = $3)
      ORDER BY i.created_at DESC`,
     [etage, chambre, lot]
   );


### PR DESCRIPTION
## Summary
- handle empty filter params in history route by comparing to text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bc6fa5e80832781dd3caeaf9c45b3