### PR TITLE
Add SQL logging for /history endpoint

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -173,6 +173,10 @@ router.get('/history', async (req, res) => {
       AND ($3 = '' OR i.lot      = $3)
     ORDER BY i.created_at DESC
   `;
+  console.log('––– HISTORY SQL –––');
+  console.log('SQL:', sql.replace(/\s+/g, ' '));
+  console.log('Params:', { etage, chambre, lot });
+  console.log('–––––––––––––––––––');
   const { rows } = await pool.query(sql, [etage, chambre, lot]);
   res.json(rows);
 });


### PR DESCRIPTION
## Summary
- log SQL query and parameters for the interventions history route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cd300720883279b9b69dfba12c45c