### PR TITLE
Fix JOIN cast in history query

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -167,7 +167,7 @@ router.get('/history', async (req, res) => {
       i.status AS state,
       i.created_at AS date
     FROM interventions i
-    JOIN users u ON u.id = i.user_id
+    JOIN users u ON u.id::text = i.user_id
     WHERE ($1 = '' OR i.floor_id::text = $1)
       AND ($2 = '' OR i.room_id ::text = $2)
       AND ($3 = '' OR i.lot      = $3)


### PR DESCRIPTION
## Summary
- cast `users.id` to text when joining in the `/history` route to avoid type mismatch

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cd4ff17b08327a3aae688f87b9003