### PR TITLE
Add default history filters

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -16,14 +16,18 @@
 
   <section id="historyTab" class="tab-content">
     <label>Étage
-      <select id="hist-floor"></select>
+      <select id="hist-floor">
+        <option value="">-- Tous les étages --</option>
+      </select>
     </label>
     <label>Chambre
-      <select id="hist-room"></select>
+      <select id="hist-room">
+        <option value="">-- Toutes les chambres --</option>
+      </select>
     </label>
     <label>Lot
       <select id="hist-lot">
-        <option value="">-- Lot --</option>
+        <option value="">-- Tous les lots --</option>
         <option value="DEPOSE">DEPOSE</option>
         <option value="Platrerie">Plâtrerie</option>
         <option value="Electricite">Électricité</option>

--- a/public/selection.js
+++ b/public/selection.js
@@ -238,7 +238,19 @@ window.addEventListener('DOMContentLoaded', async () => {
   });
   await loadUsers();
   await loadFloors('#hist-floor');
+  const histFloor = document.getElementById('hist-floor');
+  histFloor.insertAdjacentHTML('afterbegin',
+    '<option value="">-- Tous les étages --</option>'
+  );
   await loadRooms(document.getElementById('hist-floor').value, '#hist-room');
+  const histRoom = document.getElementById('hist-room');
+  histRoom.insertAdjacentHTML('afterbegin',
+    '<option value="">-- Toutes les chambres --</option>'
+  );
+  const histLot = document.getElementById('hist-lot');
+  histLot.insertAdjacentHTML('afterbegin',
+    '<option value="">-- Tous les lots --</option>'
+  );
   await loadFloors('#edit-floor');
   await loadRooms(document.getElementById('edit-floor').value, '#edit-room');
   editSubmitBtn.dataset.id = '';


### PR DESCRIPTION
## Summary
- allow user to disable floor and room filters
- add option to disable lot filter

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cd7c15fb883278259fe93ac35392a