### PR TITLE
Fix historical room selector with empty floor

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -70,7 +70,12 @@ async function loadFloors(selector) {
 async function loadRooms(floorId, selectorRoom) {
   const sel = document.querySelector(selectorRoom);
   if (!floorId) {
-    sel.innerHTML = '<option value="">-- Choisir une chambre --</option>';
+    // si on est dans l'onglet Historique, on propose “Toutes les chambres”
+    if (selectorRoom === '#hist-room') {
+      sel.innerHTML = '<option value="">-- Toutes les chambres --</option>';
+    } else {
+      sel.innerHTML = '<option value="">-- Choisir une chambre --</option>';
+    }
     return;
   }
   const res = await fetch(`/api/rooms?floorId=${encodeURIComponent(floorId)}`);
@@ -243,10 +248,6 @@ window.addEventListener('DOMContentLoaded', async () => {
     '<option value="">-- Tous les étages --</option>'
   );
   await loadRooms(document.getElementById('hist-floor').value, '#hist-room');
-  const histRoom = document.getElementById('hist-room');
-  histRoom.insertAdjacentHTML('afterbegin',
-    '<option value="">-- Toutes les chambres --</option>'
-  );
   const histLot = document.getElementById('hist-lot');
   histLot.insertAdjacentHTML('afterbegin',
     '<option value="">-- Tous les lots --</option>'


### PR DESCRIPTION
## Summary
- customize `loadRooms` so that the historical filter shows only *Toutes les chambres* when no floor is selected
- remove duplicate injection of the "Toutes les chambres" option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cdd23271483278799f4faa0f6e91f