### PR TITLE
Add debug logs for history loading

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -85,13 +85,16 @@ async function loadRooms(floorId, selectorRoom) {
 }
 
 async function loadHistory() {
+  console.log('⚙️ loadHistory() called');
   const params = new URLSearchParams({
     etage: document.getElementById('hist-floor').value || '',
     chambre: document.getElementById('hist-room').value || '',
     lot: document.getElementById('hist-lot').value || ''
   });
+  console.log('⚙️ HISTORY SQL params:', params.toString());
   const res = await fetch('/api/interventions/history?' + params.toString());
   const rows = await res.json();
+  console.log('⚙️ rows returned:', rows);
   const tbody = document.querySelector('#history-table tbody');
   tbody.innerHTML = '';
   rows.forEach(row => {


### PR DESCRIPTION
## Summary
- add console logging inside `loadHistory` to trace parameters and result rows

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ce0f578d08327a17b61741d20eb5b