### PR TITLE
Fix join type in interventions history

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -167,7 +167,7 @@ router.get('/history', async (req, res) => {
       i.status AS state,
       i.created_at AS date
     FROM interventions i
-    JOIN users u ON u.id::text = i.user_id
+    LEFT JOIN users u ON u.id::text = i.user_id
     WHERE ($1 = '' OR i.floor_id::text = $1)
       AND ($2 = '' OR i.room_id ::text = $2)
       AND ($3 = '' OR i.lot      = $3)


### PR DESCRIPTION
## Summary
- ensure `/history` route keeps results even if no user is linked to an intervention

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ce346a4048327a35888d00389e226