### PR TITLE
Affiche le nom de la personne dans l'historique

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -164,11 +164,15 @@ router.get('/history', async (req, res) => {
       i.room_id ::text AS room,
       i.lot,
       i.task,
-      i.person        AS person,
+      // on remplace l’id par le nom
+      p.username      AS person,
       i.status        AS state,
       i.created_at    AS date
     FROM interventions i
+    -- on réutilise la jointure existante pour l’auteur
     LEFT JOIN users u ON u.id::text = i.user_id
+    -- on ajoute une jointure pour la personne affectée
+    LEFT JOIN users p ON p.id::text = i.person
     WHERE ($1 = '' OR i.floor_id::text = $1)
       AND ($2 = '' OR i.room_id ::text = $2)
       AND ($3 = '' OR i.lot      = $3)


### PR DESCRIPTION
## Summary
- jointure additionnelle sur `users` pour récupérer la personne assignée
- sélection du `username` à la place de `person`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ceaa74f0083278ded6b0b79c6abfa