### PR TITLE
Fix history route person fallback

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -164,7 +164,7 @@ router.get('/history', async (req, res) => {
       i.room_id   ::text AS room,
       i.lot,
       i.task,
-      p.username      AS person,
+      COALESCE(p.username, i.person) AS person,
       i.action        AS action,
       i.status        AS state,
       i.created_at    AS date


### PR DESCRIPTION
## Summary
- display username for person when possible
- fallback to raw `interventions.person` when no user exists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d06f0bacc83278fa4340051c80701