### PR TITLE
Affichage du nom utilisateur dans l’historique

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -159,18 +159,18 @@ router.get('/history', async (req, res) => {
   const sql = `
     SELECT
       i.id,
-      u.username      AS user,
-      i.floor_id::text AS floor,
-      i.room_id   ::text AS room,
+      creator.username    AS user,
+      i.floor_id::text    AS floor,
+      i.room_id::text     AS room,
       i.lot,
       i.task,
-      COALESCE(p.username, i.person) AS person,
-      i.action        AS action,
-      i.status        AS state,
-      i.created_at    AS date
+      COALESCE(u.username, i.person) AS personne,
+      i.action            AS action,
+      i.status            AS state,
+      i.created_at        AS date
     FROM interventions i
-      LEFT JOIN users u ON u.id::text = i.user_id
-      LEFT JOIN users p ON p.id::text = i.person
+      LEFT JOIN users creator  ON creator.id::text     = i.user_id
+      LEFT JOIN users u        ON (i.person)::integer  = u.id
     WHERE ($1 = '' OR i.floor_id::text = $1)
       AND ($2 = '' OR i.room_id ::text = $2)
       AND ($3 = '' OR i.lot      = $3)


### PR DESCRIPTION
## Summary
- affiche le nom d'utilisateur lié à `person` dans la route `/history`

## Testing
- `node -c routes/interventions.js`
- `npm test` *(échoue : Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d1e0489288327bfcbd705299a7fe4