### PR TITLE
Fix history query person join

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -170,7 +170,7 @@ router.get('/history', async (req, res) => {
       i.created_at        AS date
     FROM interventions i
       LEFT JOIN users creator  ON creator.id::text     = i.user_id
-      LEFT JOIN users u        ON (i.person)::integer  = u.id
+      LEFT JOIN users u        ON u.id::text           = i.person
     WHERE ($1 = '' OR i.floor_id::text = $1)
       AND ($2 = '' OR i.room_id ::text = $2)
       AND ($3 = '' OR i.lot      = $3)


### PR DESCRIPTION
## Summary
- correct user join in interventions history query so comparison is text-to-text

## Testing
- `npm test` *(fails: Missing script)*
- `node -c routes/interventions.js`


------
https://chatgpt.com/codex/tasks/task_e_686d2472b6608327b2b6cfe3d66a634f