### PR TITLE
Change alias to 'person' in history API

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -164,7 +164,7 @@ router.get('/history', async (req, res) => {
       i.room_id::text     AS room,
       i.lot,
       i.task,
-      COALESCE(u.username, i.person) AS personne,
+      COALESCE(u.username, i.person) AS person,
       i.action            AS action,
       i.status            AS state,
       i.created_at        AS date


### PR DESCRIPTION
## Summary
- ensure the `/history` route returns a `person` field instead of `personne`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e19fe33b083279b012c8aea17e27d