### PR TITLE
Split floor and room columns

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -46,7 +46,8 @@
           <th>Utilisateur</th>
           <th>Action</th>
           <th>Lot</th>
-          <th>Étage-Chambre</th>
+          <th>Étage</th>
+          <th>Chambre</th>
           <th>Tâche</th>
           <th>Dernière Modif</th>
           <th>État</th>

--- a/public/selection.js
+++ b/public/selection.js
@@ -112,16 +112,17 @@ function renderHistory(rows) {
   const tbody = document.querySelector('#history-table tbody');
   tbody.innerHTML = '';
   rows.forEach(h => {
-    const emplacement = `${h.floor} / ${h.room}`;
+    // plus besoin de `emplacement`
     const vals = [
-      window.userMap[h.user_id] || h.user_id,          // Utilisateur
-      h.action,                                        // Action
-      h.lot,                                           // Lot
-      emplacement,                                     // Étage-Chambre
-      h.task,                                          // Tâche
-      window.userMap[h.person]  || h.person,           // Personne
-      statusLabels[h.state]  || h.state,               // État
-      new Date(h.date).toLocaleString()                // Date/Heure
+      window.userMap[h.user_id] || h.user_id,  // Utilisateur
+      h.action,                                // Action
+      h.lot,                                   // Lot
+      h.floor || '',                           // Étage
+      h.room  || '',                           // Chambre
+      h.task,                                  // Tâche
+      window.userMap[h.person]  || h.person,   // Personne
+      statusLabels[h.state]  || h.state,       // État
+      new Date(h.date).toLocaleString()        // Date/Heure
     ];
     const tr = document.createElement('tr');
     vals.forEach(v => {


### PR DESCRIPTION
## Summary
- replace "Étage-Chambre" by separate headers in history table
- show `floor` and `room` columns in the history rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e2cdeec848327b9ea4fa57645c8e0