### PR TITLE
Automatique affichage historique

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -285,7 +285,9 @@ window.addEventListener('DOMContentLoaded', async () => {
   await loadFloors('#edit-floor');
   await loadRooms(document.getElementById('edit-floor').value, '#edit-room');
   editSubmitBtn.dataset.id = '';
+  // Afficher d'emblée l'Historique
   showTab('historyTab');
+  await loadHistory();
   document.getElementById('hist-floor').addEventListener('change', e => loadRooms(e.target.value, '#hist-room'));
   document.getElementById('edit-floor').addEventListener('change', e => loadRooms(e.target.value, '#edit-room'));
   document.getElementById('hist-refresh').addEventListener('click', loadHistory);


### PR DESCRIPTION
## Summary
- intègre `loadHistory()` dans le listener `DOMContentLoaded` existant pour éviter un second gestionnaire

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e30cf5d44832781bfdf74c6da4ee9