### PR TITLE
Fix viewport meta in selection page

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=0.7, minimum-scale=0.5, maximum-scale=1">
   <title>Gestion des tâches</title>
   <link rel="stylesheet" href="selection.css">
 </head>


### PR DESCRIPTION
## Summary
- adjust viewport meta tag in `selection.html` so mobile view starts zoomed out

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e34b9d3f4832784e85f1c06a2be24