### PR TITLE
Add preview table in edit tab

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -60,6 +60,18 @@
   </section>
 
   <section id="editTab" class="tab-content" hidden>
+    <section id="previewTab">
+      <h3>Tâches existantes</h3>
+      <table id="preview-table">
+        <thead>
+          <tr>
+            <th>Utilisateur</th><th>Action</th><th>Lot</th><th>Étage</th>
+            <th>Chambre</th><th>Tâche</th><th>Personne</th><th>État</th><th>Date/Heure</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
     <label>Étage
       <select id="edit-floor"></select>
     </label>


### PR DESCRIPTION
## Summary
- display existing tasks in preview table inside edit tab
- support custom table selector in `renderHistory`
- add `loadPreview` to fetch history for edit selection
- hook preview refresh on tab change and dropdown selections
- load preview when editing an intervention
- omit edit column when rendering preview table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e3896340c83279a88a8688d081f53