### PR TITLE
Update preview section behaviour

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -60,13 +60,13 @@
   </section>
 
   <section id="editTab" class="tab-content" hidden>
-    <section id="previewTab">
+    <section id="previewTab" hidden>
       <h3>Tâches existantes</h3>
       <table id="preview-table">
         <thead>
           <tr>
             <th>Utilisateur</th><th>Action</th><th>Lot</th><th>Étage</th>
-            <th>Chambre</th><th>Tâche</th><th>Personne</th><th>État</th><th>Date/Heure</th>
+            <th>Chambre</th><th>Tâche</th><th>Personne</th><th>État</th><th>Date/Heure</th><th>Modifier</th>
           </tr>
         </thead>
         <tbody></tbody>

--- a/public/selection.js
+++ b/public/selection.js
@@ -109,7 +109,13 @@ async function loadHistory() {
 }
 
 async function loadPreview() {
-  const floor = document.getElementById('edit-floor').value || '';
+  const floor = document.getElementById('edit-floor').value;
+  const previewSection = document.getElementById('previewTab');
+  if (!floor) {
+    previewSection.hidden = true;
+    return;
+  }
+  previewSection.hidden = false;
   const room  = document.getElementById('edit-room').value || '';
   const lot   = document.getElementById('edit-lot').value || '';
   const params = new URLSearchParams({ etage: floor, chambre: room, lot });
@@ -141,8 +147,8 @@ function renderHistory(rows, tableSelector = '#history-table') {
       td.textContent = v;
       tr.appendChild(td);
     });
-    // seulement pour l'historique "véritable", on ajoute le bouton d'édition
-    if (tableSelector === '#history-table') {
+    // on ajoute le bouton d'édition pour l'historique et la prévisualisation
+    if (['#history-table', '#preview-table'].includes(tableSelector)) {
       const tdEdit = document.createElement('td');
       const btn = document.createElement('button');
       btn.className = 'hist-edit';


### PR DESCRIPTION
## Summary
- hide preview section until a floor is selected
- show edit icon in preview table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e3d4b09888327a712300ebba0d988