### PR TITLE
Add comment & photo history tables

### DIFF
--- a/public/selection.css
+++ b/public/selection.css
@@ -159,3 +159,11 @@ button:focus {
 .info-menu li:hover {
   background: #eee;
 }
+
+.back-btn {
+  margin-bottom: 0.5rem;
+  display: inline-block;
+  background: #eee;
+  padding: 0.3rem;
+  border-radius: 4px;
+}

--- a/public/selection.html
+++ b/public/selection.html
@@ -110,11 +110,14 @@
   </section>
 
   <section id="commentTab" class="tab-content" hidden>
+    <button id="comment-back" class="back-btn">← Retour</button>
+    <ul id="comment-list"></ul>
     <textarea id="comment-text"></textarea>
     <button id="comment-send">Envoyer</button>
   </section>
 
   <section id="photoTab" class="tab-content" hidden>
+    <button id="photo-back" class="back-btn">← Retour</button>
     <input id="photo-file" type="file" multiple>
     <button id="photo-send">Envoyer</button>
     <ul id="photo-list"></ul>

--- a/server.js
+++ b/server.js
@@ -27,6 +27,36 @@ const pool = require("./db");
       created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
     );
   `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS interventions_history (
+      id              SERIAL      PRIMARY KEY,
+      intervention_id INTEGER     NOT NULL REFERENCES interventions(id) ON DELETE CASCADE,
+      floor_id        TEXT        NOT NULL,
+      room_id         TEXT        NOT NULL,
+      lot             TEXT        NOT NULL,
+      task            TEXT        NOT NULL,
+      person          TEXT,
+      status          TEXT        NOT NULL,
+      action          TEXT        NOT NULL,
+      created_at      TIMESTAMPTZ NOT NULL
+    );
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS interventions_comments (
+      id              SERIAL      PRIMARY KEY,
+      intervention_id INTEGER     NOT NULL REFERENCES interventions(id) ON DELETE CASCADE,
+      text            TEXT        NOT NULL,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS interventions_photos (
+      id              SERIAL      PRIMARY KEY,
+      intervention_id INTEGER     NOT NULL REFERENCES interventions(id) ON DELETE CASCADE,
+      url             TEXT        NOT NULL,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
 })().catch(console.error);
 
 const app = express();


### PR DESCRIPTION
## Summary
- style back buttons for better visibility
- load comments and photos after setting the current task ID
- return history records with `status` aliased as `state`
- expose routes to fetch comments and photos
- persist previous state in `interventions_history`
- create history, comment and photo tables automatically
- fix photo list markup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e5fb29f4883279dbcf01ef4e8e1a3