### PR TITLE
Rendre les boutons retour visibles et améliorer l’historique

### DIFF
--- a/public/selection.css
+++ b/public/selection.css
@@ -163,7 +163,31 @@ button:focus {
 .back-btn {
   margin-bottom: 0.5rem;
   display: inline-block;
-  background: #eee;
-  padding: 0.3rem;
-  border-radius: 4px;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  padding: .4rem .8rem;
+  border-radius: .25rem;
+  cursor: pointer;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+.back-btn:hover {
+  background: #0056b3;
+}
+
+/* Nouveau style pour le tableau d’historique */
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.history-table th,
+.history-table td {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+.history-table th {
+  background: #f7f7f7;
 }

--- a/public/selection.js
+++ b/public/selection.js
@@ -53,16 +53,31 @@ const statusLabels = {
 function showTaskHistory(logs) {
   const modal = document.getElementById('history-modal');
   const content = document.getElementById('history-content');
-  const items = logs.map(l =>
-    `<li>
-       ${new Date(l.created_at).toLocaleString()} —
-       Lot: ${l.lot}, Tâche: ${l.task},
-       Modifié par: ${window.userMap[l.user_id]||l.user_id},
-       Assigné à: ${window.userMap[l.person]||l.person},
-       État: ${l.state}, Action: ${l.action}
-     </li>`
-  ).join('');
-  content.innerHTML = `<ul>${items}</ul>`;
+  const rows = logs.map(l => `
+    <tr>
+      <td>${new Date(l.created_at).toLocaleString()}</td>
+      <td>${l.lot}</td>
+      <td>${l.task}</td>
+      <td>${window.userMap[l.user_id]||l.user_id}</td>
+      <td>${window.userMap[l.person]||l.person}</td>
+      <td>${l.state}</td>
+      <td>${l.action}</td>
+    </tr>
+  `).join('');
+  content.innerHTML = `
+    <table class="history-table">
+      <thead>
+        <tr>
+          <th>Date</th><th>Lot</th><th>Tâche</th>
+          <th>Modifié par</th><th>Assigné à</th>
+          <th>État</th><th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  `;
   modal.hidden = false;
 }
 
@@ -394,8 +409,10 @@ window.addEventListener('DOMContentLoaded', async () => {
       if (e.target.dataset.tab === 'editTab') loadPreview();
     }
   });
-  document.getElementById('comment-back').addEventListener('click', () => showTab('historyTab'));
-  document.getElementById('photo-back').addEventListener('click', () => showTab('historyTab'));
+  document.getElementById('comment-back')
+    .addEventListener('click', () => showTab('historyTab'));
+  document.getElementById('photo-back')
+    .addEventListener('click', () => showTab('historyTab'));
   const modal = document.getElementById('history-modal');
   document.getElementById('close-history').addEventListener('click', () => {
     modal.hidden = true;


### PR DESCRIPTION
## Summary
- modernize the back button styling so it stays visible
- present task history in a professional table

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686e71999c7483279883a17cc7273707