### PR TITLE
Fix session use before routes

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -52,8 +52,10 @@ router.get('/users', async (req, res) => {
 
 // POST new intervention
 router.post('/', async (req, res) => {
-  const { floorId, roomId, userId, lot, task, status, person } = req.body;
-  if (!floorId || !roomId || !userId || !lot || !task) {
+  const userId = req.session?.userId;
+  if (!userId) return res.status(401).json({ error: 'Non authentifié' });
+  const { floorId, roomId, lot, task, status, person } = req.body;
+  if (!floorId || !roomId || !lot || !task) {
     return res.status(400).json({ error: 'Données manquantes' });
   }
   try {
@@ -264,7 +266,9 @@ router.post('/:id/comment', async (req, res) => {
 
 // PUT update an intervention
 router.put('/:id', async (req, res) => {
-  const { floor, room, lot, task, person, state, userId } = req.body;
+  const userId = req.session?.userId;
+  if (!userId) return res.status(401).json({ error: 'Non authentifié' });
+  const { floor, room, lot, task, person, state } = req.body;
   try {
     // 1️⃣ lire l’état courant
     const before = (await pool.query(

--- a/server.js
+++ b/server.js
@@ -86,19 +86,6 @@ const pool = require("./db");
 
 const app = express();
 
-// Configuration CORS pour autoriser les cookies/sessions
-app.use(cors({
-  origin: "http://localhost:3000", // Remplace par l'URL de ton frontend en prod
-  credentials: true,
-}));
-
-app.use(express.json());
-
-// Gestion des interventions (POST + GET /api/interventions)
-app.use('/api/interventions', interventionsRoutes);
-app.use('/uploads', express.static('uploads'));
-
-
 // Configuration express-session
 app.use(session({
   secret: "tonSecretUltraSecret", // Change cette clé en une valeur complexe
@@ -110,6 +97,18 @@ app.use(session({
     maxAge: 1000 * 60 * 60 * 24, // 1 jour
   },
 }));
+
+// Configuration CORS pour autoriser les cookies/sessions
+app.use(cors({
+  origin: "http://localhost:3000", // Remplace par l'URL de ton frontend en prod
+  credentials: true,
+}));
+
+app.use(express.json());
+
+// Gestion des interventions (POST + GET /api/interventions)
+app.use('/api/interventions', interventionsRoutes);
+app.use('/uploads', express.static('uploads'));
 
 // Servir les fichiers uploadés
 app.use("/uploads", express.static(path.join(__dirname, "uploads")));


### PR DESCRIPTION
## Summary
- move session configuration before registering routes
- use `req.session.userId` in intervention POST & PUT routes

## Testing
- `npm test` *(fails: missing script and cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686f80a40f348327b444f04d73f13a80