### PR TITLE
Use session in interventions and include credentials

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -136,7 +136,10 @@ async function loadHistory() {
     lot: document.getElementById('hist-lot').value || ''
   });
   console.log('⚙️ HISTORY SQL params:', params.toString());
-  const res = await fetch('/api/interventions/history?' + params.toString());
+  const res = await fetch('/api/interventions/history?' + params.toString(), {
+    method: 'GET',
+    credentials: 'include'
+  });
   const rows = await res.json();
   console.log('⚙️ rows returned:', rows);
   renderHistory(rows, '#history-table');
@@ -153,7 +156,10 @@ async function loadPreview() {
   const room  = document.getElementById('edit-room').value || '';
   const lot   = document.getElementById('edit-lot').value || '';
   const params = new URLSearchParams({ etage: floor, chambre: room, lot });
-  const res = await fetch('/api/interventions/history?' + params.toString());
+  const res = await fetch('/api/interventions/history?' + params.toString(), {
+    method: 'GET',
+    credentials: 'include'
+  });
   const rows = await res.json();
   renderHistory(rows, '#preview-table');
 }
@@ -209,7 +215,10 @@ function renderHistory(rows, tableSelector = '#history-table') {
       menu.addEventListener('click', async e => {
         const action = e.target.dataset.action;
         if (action === 'view-history') {
-          const res = await fetch(`/api/interventions/${h.id}/history`);
+          const res = await fetch(`/api/interventions/${h.id}/history`, {
+            method: 'GET',
+            credentials: 'include'
+          });
           const logs = await res.json();
           if (typeof showTaskHistory === 'function') {
             showTaskHistory(logs);
@@ -291,6 +300,7 @@ editSubmitBtn.addEventListener('click', async function () {
   if (btn.dataset.id) {
     await fetch(`/api/interventions/${btn.dataset.id}`, {
       method: 'PUT',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         floor: payload.floor,
@@ -303,6 +313,7 @@ editSubmitBtn.addEventListener('click', async function () {
   } else {
     const res = await fetch('/api/interventions/bulk', {
       method: 'POST',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     });
@@ -338,6 +349,7 @@ document.getElementById('comment-send').addEventListener('click', async () => {
   const text = document.getElementById('comment-text').value;
   await fetch(`/api/interventions/${currentId}/comment`, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text })
   });
@@ -347,7 +359,10 @@ document.getElementById('comment-send').addEventListener('click', async () => {
 
 async function loadComments() {
   if (!currentId) return;
-  const res = await fetch(`/api/interventions/${currentId}/comments`);
+  const res = await fetch(`/api/interventions/${currentId}/comments`, {
+    method: 'GET',
+    credentials: 'include'
+  });
   const comments = await res.json();
   const list = document.getElementById('comment-list');
   list.innerHTML = comments
@@ -357,7 +372,10 @@ async function loadComments() {
 
 async function loadPhotos() {
   if (!currentId) return;
-  const res = await fetch(`/api/interventions/${currentId}/photos`);
+  const res = await fetch(`/api/interventions/${currentId}/photos`, {
+    method: 'GET',
+    credentials: 'include'
+  });
   const urls = await res.json();
   document.getElementById('photo-list').innerHTML =
     urls.map(u => `<li><img src="${u}"></li>`).join('');
@@ -368,7 +386,11 @@ document.getElementById('photo-send').addEventListener('click', async () => {
   const files = document.getElementById('photo-file').files;
   const fd = new FormData();
   for (const f of files) fd.append('photos', f);
-  const res = await fetch(`/api/interventions/${currentId}/photos`, { method: 'POST', body: fd });
+  const res = await fetch(`/api/interventions/${currentId}/photos`, {
+    method: 'POST',
+    credentials: 'include',
+    body: fd
+  });
   const urls = await res.json();
   const list = document.getElementById('photo-list');
   list.innerHTML = urls.map(u => `<li><img src="${u}"></li>`).join('');

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -52,8 +52,10 @@ router.get('/users', async (req, res) => {
 
 // POST new intervention
 router.post('/', async (req, res) => {
-  const { floorId, roomId, userId, lot, task, status, person } = req.body;
-  if (!floorId || !roomId || !userId || !lot || !task) {
+  const userId = req.session?.userId;
+  if (!userId) return res.status(401).json({ error: 'Non authentifié' });
+  const { floorId, roomId, lot, task, status, person } = req.body;
+  if (!floorId || !roomId || !lot || !task) {
     return res.status(400).json({ error: 'Données manquantes' });
   }
   try {
@@ -264,7 +266,9 @@ router.post('/:id/comment', async (req, res) => {
 
 // PUT update an intervention
 router.put('/:id', async (req, res) => {
-  const { floor, room, lot, task, person, state, userId } = req.body;
+  const userId = req.session?.userId;
+  if (!userId) return res.status(401).json({ error: 'Non authentifié' });
+  const { floor, room, lot, task, person, state } = req.body;
   try {
     // 1️⃣ lire l’état courant
     const before = (await pool.query(

--- a/server.js
+++ b/server.js
@@ -86,30 +86,19 @@ const pool = require("./db");
 
 const app = express();
 
-// Configuration CORS pour autoriser les cookies/sessions
-app.use(cors({
-  origin: "http://localhost:3000", // Remplace par l'URL de ton frontend en prod
-  credentials: true,
-}));
-
-app.use(express.json());
-
-// Gestion des interventions (POST + GET /api/interventions)
-app.use('/api/interventions', interventionsRoutes);
-app.use('/uploads', express.static('uploads'));
-
-
-// Configuration express-session
+// —————————————
+// 1️⃣ CONFIGURATION DE LA SESSION
 app.use(session({
-  secret: "tonSecretUltraSecret", // Change cette clé en une valeur complexe
+  secret: "tonSecretUltraSecret",
   resave: false,
   saveUninitialized: false,
-  cookie: {
-    secure: false, // true si HTTPS, false en dev local
-    httpOnly: true,
-    maxAge: 1000 * 60 * 60 * 24, // 1 jour
-  },
+  cookie: { secure: false, httpOnly: true, maxAge: 86400000 }
 }));
+
+app.use(cors({ origin: "http://localhost:3000", credentials: true }));
+app.use(express.json());
+app.use('/api/interventions', interventionsRoutes);
+app.use('/uploads', express.static('uploads'));
 
 // Servir les fichiers uploadés
 app.use("/uploads", express.static(path.join(__dirname, "uploads")));


### PR DESCRIPTION
## Summary
- configure `express-session` before API routes
- read `userId` from the session in intervention routes
- send credentials on all `/api/interventions` fetch calls

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fa9f600bc8327812ff2ab9831374c