### PR TITLE
Fix history route to fallback on raw user id

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -219,14 +219,16 @@ router.get('/:id/history', async (req, res) => {
   try {
     const { rows } = await pool.query(
       `SELECT
-         ih.intervention_id AS id,
-         u_old.username AS person_old,
-         u_new.username AS person_new,
-         ih.floor_old,   ih.floor_new,
-         ih.room_old,    ih.room_new,
-         ih.lot_old,     ih.lot_new,
-         ih.task_old,    ih.task_new,
-         ih.state_old,   ih.state_new,
+       ih.intervention_id AS id,
+       -- on affiche d’abord le username, sinon on retombe sur l’ID stocké
+       COALESCE(u_old.username, ih.person_old::text) AS person_old,
+       COALESCE(u_new.username, ih.person_new::text) AS person_new,
+       ih.floor_old,   ih.floor_new,
+       ih.room_old,    ih.room_new,
+       ih.lot_old,     ih.lot_new,
+       ih.task_old,    ih.task_new,
+       -- …
+       ih.state_old,   ih.state_new,
          ih.action,
          ih.created_at
        FROM interventions_history ih


### PR DESCRIPTION
## Summary
- return raw `person_old` and `person_new` ids when username missing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68765fa5699c8327bcece48cabb9c623