### PR TITLE
Add comment author selection

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -113,6 +113,9 @@
     <button id="comment-back" class="back-btn">← Retour</button>
     <div class="comments-container">
       <div class="comment-form card">
+        <select id="comment-author" class="person">
+          <!-- options injectées par JS, comme pour les interventions -->
+        </select>
         <textarea id="comment-text" placeholder="Écrire un commentaire…"></textarea>
         <button id="comment-send" class="btn-primary">Envoyer</button>
       </div>

--- a/public/selection.js
+++ b/public/selection.js
@@ -110,6 +110,12 @@ async function loadUsers() {
   });
 }
 
+// Dès que la page est prête, on injecte les mêmes options de users
+document.addEventListener('DOMContentLoaded', () => {
+  const sel = document.getElementById('comment-author');
+  if (sel) sel.innerHTML = userOptions;  // userOptions défini dans loadUsers()
+});
+
 async function loadFloors(selector) {
   const res = await fetch('/api/floors');
   const floors = await res.json();
@@ -343,10 +349,11 @@ async function openForEdit(row) {
 document.getElementById('comment-send').addEventListener('click', async () => {
   if (!currentId) return;
   const text = document.getElementById('comment-text').value;
+  const author = document.getElementById('comment-author').value;
   await fetch(`/api/interventions/${currentId}/comment`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text })
+    body: JSON.stringify({ text, author })
   });
   await loadComments();
   document.getElementById('comment-text').value = '';

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -249,7 +249,11 @@ router.get('/:id/history', async (req, res) => {
 
 router.get('/:id/comments', async (req, res) => {
   const { rows } = await pool.query(
-    'SELECT text, created_at FROM interventions_comments WHERE intervention_id=$1 ORDER BY created_at DESC',
+    `SELECT c.text, c.created_at, c.created_by AS author_id, u.username AS author
+       FROM interventions_comments c
+  LEFT JOIN users u ON u.id = c.created_by
+      WHERE c.intervention_id = $1
+   ORDER BY c.created_at DESC`,
     [req.params.id]
   );
   res.json(rows);
@@ -264,11 +268,11 @@ router.get('/:id/photos', async (req, res) => {
 });
 
 router.post('/:id/comment', async (req, res) => {
-  const { text } = req.body;
+  const { text, author } = req.body;
   await pool.query(
-    `INSERT INTO interventions_comments (intervention_id, text, created_at)
-     VALUES ($1, $2, now())`,
-    [req.params.id, text]
+    `INSERT INTO interventions_comments (intervention_id, text, created_by, created_at)
+     VALUES ($1, $2, $3, now())`,
+    [req.params.id, text, author]
   );
   res.json({ success: true });
 });

--- a/server.js
+++ b/server.js
@@ -73,9 +73,13 @@ const pool = require("./db");
       id              SERIAL      PRIMARY KEY,
       intervention_id INTEGER     NOT NULL REFERENCES interventions(id) ON DELETE CASCADE,
       text            TEXT        NOT NULL,
+      created_by      INTEGER     NOT NULL REFERENCES users(id),
       created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
     );
   `);
+  await pool.query(
+    'ALTER TABLE interventions_comments ADD COLUMN IF NOT EXISTS created_by INTEGER NOT NULL REFERENCES users(id)'
+  );
   await pool.query(`
     CREATE TABLE IF NOT EXISTS interventions_photos (
       id              SERIAL      PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add dropdown of users in comment form
- populate comment author select on page load
- send selected author on comment creation
- store author_id when creating comment and include username in comments API
- ensure database table `interventions_comments` has `created_by`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687764d8ba088327bdb857497534e5af