### PR TITLE
Improve selection table styling

### DIFF
--- a/public/selection.css
+++ b/public/selection.css
@@ -176,17 +176,24 @@ button:focus {
   background: #0056b3;
 }
 
-/* Nouveau style pour le tableau d’historique */
+/* Styles communs aux tableaux de données */
+.data-table,
 .history-table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 1rem;
 }
+.data-table th,
+.data-table td,
 .history-table th,
 .history-table td {
-  padding: 0.5rem;
+  padding: 10px;
   border: 1px solid #ddd;
   text-align: left;
+}
+.data-table tbody tr:nth-child(odd),
+.history-table tbody tr:nth-child(odd) {
+  background-color: #f5f5f5;
 }
 .history-table th {
   background: #f7f7f7;

--- a/public/selection.html
+++ b/public/selection.html
@@ -40,7 +40,7 @@
       </select>
     </label>
     <button id="hist-refresh">Rafraîchir</button>
-    <table id="history-table">
+    <table id="history-table" class="data-table">
       <thead>
         <tr>
           <th>Utilisateur</th>
@@ -63,7 +63,7 @@
   <section id="editTab" class="tab-content" hidden>
     <section id="previewTab" hidden>
       <h3>Tâches existantes</h3>
-      <table id="preview-table">
+      <table id="preview-table" class="data-table">
         <thead>
           <tr>
             <th>Utilisateur</th><th>Action</th><th>Lot</th><th>Étage</th>
@@ -82,7 +82,7 @@
     <label>Lot
       <select id="edit-lot"></select>
     </label>
-    <table id="edit-table">
+    <table id="edit-table" class="data-table">
       <thead>
         <tr>
           <th>Tâche</th>


### PR DESCRIPTION
## Summary
- add `data-table` class to history, preview and edit tables
- style data tables in `selection.css` with zebra striping

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687781c14d74832798a41391a33b12d8