### PR TITLE
Improve table display on mobile

### DIFF
--- a/public/selection.css
+++ b/public/selection.css
@@ -193,7 +193,7 @@ button:focus {
 }
 .data-table tbody tr:nth-child(odd),
 .history-table tbody tr:nth-child(odd) {
-  background-color: #f5f5f5;
+  background-color: #eaeaea;
 }
 .history-table th {
   background: #f7f7f7;
@@ -210,6 +210,16 @@ button:focus {
 .history-table td.changed {
   background-color: #ffecec;
   font-weight: 600;
+}
+
+/* Conteneur responsive pour les tableaux */
+.table-container {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+table {
+  min-width: 800px;
 }
 
 /* Styles pour la zone de commentaires */

--- a/public/selection.html
+++ b/public/selection.html
@@ -40,6 +40,7 @@
       </select>
     </label>
     <button id="hist-refresh">Rafraîchir</button>
+    <div class="table-container">
     <table id="history-table" class="data-table">
       <thead>
         <tr>
@@ -58,11 +59,13 @@
       </thead>
       <tbody></tbody>
     </table>
+    </div>
   </section>
 
   <section id="editTab" class="tab-content" hidden>
     <section id="previewTab" hidden>
       <h3>Tâches existantes</h3>
+      <div class="table-container">
       <table id="preview-table" class="data-table">
         <thead>
           <tr>
@@ -72,6 +75,7 @@
         </thead>
         <tbody></tbody>
       </table>
+      </div>
     </section>
     <label>Étage
       <select id="edit-floor"></select>
@@ -82,6 +86,7 @@
     <label>Lot
       <select id="edit-lot"></select>
     </label>
+    <div class="table-container">
     <table id="edit-table" class="data-table">
       <thead>
         <tr>
@@ -94,6 +99,7 @@
       </thead>
       <tbody></tbody>
     </table>
+    </div>
     <template id="edit-row-template">
       <tr>
         <td><select name="task"></select></td>


### PR DESCRIPTION
## Summary
- tweak zebra row color for data tables
- add responsive table container styles
- wrap all tables in responsive container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687783529ca08327a0888d334f55541b