### PR TITLE
Add export PDF and Excel features

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "multer": "^1.4.5-lts.1",
     "pg": "^8.11.3",
     "cloudinary": "^1.37.2",
-    "multer-storage-cloudinary": "^4.0.0"
+    "multer-storage-cloudinary": "^4.0.0",
+    "pdfkit": "^0.15.0",
+    "exceljs": "^4.3.0"
   }
 }

--- a/public/selection.html
+++ b/public/selection.html
@@ -40,6 +40,8 @@
       </select>
     </label>
     <button id="hist-refresh">Rafraîchir</button>
+    <button id="export-pdf">Exporter PDF</button>
+    <button id="export-excel">Exporter Excel</button>
     <div class="table-container">
     <table id="history-table" class="data-table">
       <thead>

--- a/public/selection.js
+++ b/public/selection.js
@@ -97,6 +97,21 @@ function showTab(tabId) {
   });
 }
 
+function downloadFile(url, filename) {
+  fetch(url)
+    .then(res => res.blob())
+    .then(blob => {
+      const a = document.createElement('a');
+      const objectUrl = URL.createObjectURL(blob);
+      a.href = objectUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(objectUrl);
+      a.remove();
+    });
+}
+
 async function loadUsers() {
   const res = await fetch('/api/users');
   const users = await res.json();
@@ -421,6 +436,22 @@ window.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('hist-floor').addEventListener('change', e => loadRooms(e.target.value, '#hist-room'));
   document.getElementById('edit-floor').addEventListener('change', e => loadRooms(e.target.value, '#edit-room'));
   document.getElementById('hist-refresh').addEventListener('click', loadHistory);
+  document.getElementById('export-pdf').addEventListener('click', () => {
+    const params = new URLSearchParams({
+      etage: document.getElementById('hist-floor').value || '',
+      chambre: document.getElementById('hist-room').value || '',
+      lot: document.getElementById('hist-lot').value || ''
+    });
+    downloadFile('/api/export/pdf?' + params.toString(), 'interventions.pdf');
+  });
+  document.getElementById('export-excel').addEventListener('click', () => {
+    const params = new URLSearchParams({
+      etage: document.getElementById('hist-floor').value || '',
+      chambre: document.getElementById('hist-room').value || '',
+      lot: document.getElementById('hist-lot').value || ''
+    });
+    downloadFile('/api/export/excel?' + params.toString(), 'interventions.xlsx');
+  });
   document.querySelector('.tabs').addEventListener('click', e => {
     if (e.target.tagName === 'BUTTON') {
       showTab(e.target.dataset.tab);

--- a/routes/export.js
+++ b/routes/export.js
@@ -1,0 +1,119 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+const PDFDocument = require('pdfkit');
+const ExcelJS = require('exceljs');
+const fs = require('fs');
+const path = require('path');
+
+function loadUsersMap() {
+  const csvPath = path.join(__dirname, '../db/users.csv');
+  if (!fs.existsSync(csvPath)) return {};
+  const text = fs.readFileSync(csvPath, 'latin1');
+  const lines = text.split(/\r?\n/).slice(1).filter(l => l.trim());
+  const map = {};
+  lines.forEach((line, idx) => {
+    const [id, name] = line.split(';');
+    const key = id.trim() || String(idx + 1);
+    map[key] = name ? name.trim() : key;
+  });
+  return map;
+}
+
+async function fetchRows(etage, chambre, lot) {
+  const sql = `
+    SELECT user_id, action, lot, floor_id::text AS floor, room_id::text AS room,
+           task, status, created_at
+      FROM interventions
+      WHERE ($1='' OR floor_id::text=$1)
+        AND ($2='' OR room_id::text=$2)
+        AND ($3='' OR lot=$3)
+      ORDER BY created_at DESC`;
+  const { rows } = await pool.query(sql, [etage, chambre, lot]);
+  return rows;
+}
+
+router.get('/pdf', async (req, res) => {
+  try {
+    const etage = req.query.etage || '';
+    const chambre = req.query.chambre || '';
+    const lot = req.query.lot || '';
+    const rows = await fetchRows(etage, chambre, lot);
+    const userMap = loadUsersMap();
+
+    const doc = new PDFDocument({ margin: 30, size: 'A4' });
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'attachment; filename="interventions.pdf"');
+    doc.pipe(res);
+
+    const headers = ['Utilisateur','Action','Lot','Étage','Chambre','Tâche','État','Date'];
+    doc.fontSize(12);
+    doc.text(headers.join(' | '));
+    doc.moveDown();
+
+    rows.forEach(r => {
+      const line = [
+        userMap[r.user_id] || r.user_id,
+        r.action,
+        r.lot,
+        r.floor,
+        r.room,
+        r.task,
+        r.status,
+        new Date(r.created_at).toLocaleString('fr-FR')
+      ].join(' | ');
+      doc.text(line);
+    });
+
+    doc.end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Erreur export PDF');
+  }
+});
+
+router.get('/excel', async (req, res) => {
+  try {
+    const etage = req.query.etage || '';
+    const chambre = req.query.chambre || '';
+    const lot = req.query.lot || '';
+    const rows = await fetchRows(etage, chambre, lot);
+    const userMap = loadUsersMap();
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet('Interventions');
+
+    sheet.columns = [
+      { header: 'Utilisateur', key: 'utilisateur', width: 20 },
+      { header: 'Action', key: 'action', width: 15 },
+      { header: 'Lot', key: 'lot', width: 15 },
+      { header: 'Étage', key: 'etage', width: 10 },
+      { header: 'Chambre', key: 'chambre', width: 12 },
+      { header: 'Tâche', key: 'tache', width: 30 },
+      { header: 'État', key: 'etat', width: 15 },
+      { header: 'Date', key: 'date', width: 20 },
+    ];
+
+    rows.forEach(r => {
+      sheet.addRow({
+        utilisateur: userMap[r.user_id] || r.user_id,
+        action: r.action,
+        lot: r.lot,
+        etage: r.floor,
+        chambre: r.room,
+        tache: r.task,
+        etat: r.status,
+        date: new Date(r.created_at).toLocaleString('fr-FR')
+      });
+    });
+
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', 'attachment; filename="interventions.xlsx"');
+    await workbook.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Erreur export Excel');
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const interventionsRoutes = require("./routes/interventions");
 const usersRoutes = require("./routes/users");
 const floorsRoutes = require("./routes/floors");
 const roomsRoutes = require("./routes/rooms");
+const exportRoutes = require("./routes/export");
 const pool = require("./db");
 
 (async () => {
@@ -124,6 +125,7 @@ app.use("/api/floors", floorsRoutes);
 app.use("/api/rooms", roomsRoutes);
 app.use("/api/auth", authRoutes);
 app.use('/api/bulles', bullesRoutes);
+app.use('/api/export', exportRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Serveur en ligne sur le port ${PORT}`));


### PR DESCRIPTION
## Summary
- add dependencies for pdfkit and exceljs
- create new `/api/export/pdf` and `/api/export/excel` routes
- expose export routes via Express
- add download helper in selection.js and export buttons in selection.html

## Testing
- `node -e "require('./routes/export')"` *(fails: Cannot find module 'pdfkit')*

------
https://chatgpt.com/codex/tasks/task_e_68778573ec548327a0be0c3b31b88031