### PR TITLE
Add date filter for exports

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -39,6 +39,12 @@
         <option value="Repose">Repose</option>
       </select>
     </label>
+    <label>Du
+      <input type="date" id="date-start">
+    </label>
+    <label>Au
+      <input type="date" id="date-end">
+    </label>
     <button id="hist-refresh">Rafraîchir</button>
     <button id="export-pdf">Exporter PDF</button>
     <button id="export-excel">Exporter Excel</button>

--- a/public/selection.js
+++ b/public/selection.js
@@ -440,7 +440,9 @@ window.addEventListener('DOMContentLoaded', async () => {
     const params = new URLSearchParams({
       etage: document.getElementById('hist-floor').value || '',
       chambre: document.getElementById('hist-room').value || '',
-      lot: document.getElementById('hist-lot').value || ''
+      lot: document.getElementById('hist-lot').value || '',
+      start: document.getElementById('date-start').value || '',
+      end: document.getElementById('date-end').value || ''
     });
     downloadFile('/api/export/pdf?' + params.toString(), 'interventions.pdf');
   });
@@ -448,7 +450,9 @@ window.addEventListener('DOMContentLoaded', async () => {
     const params = new URLSearchParams({
       etage: document.getElementById('hist-floor').value || '',
       chambre: document.getElementById('hist-room').value || '',
-      lot: document.getElementById('hist-lot').value || ''
+      lot: document.getElementById('hist-lot').value || '',
+      start: document.getElementById('date-start').value || '',
+      end: document.getElementById('date-end').value || ''
     });
     downloadFile('/api/export/excel?' + params.toString(), 'interventions.xlsx');
   });

--- a/routes/export.js
+++ b/routes/export.js
@@ -20,7 +20,7 @@ function loadUsersMap() {
   return map;
 }
 
-async function fetchRows(etage, chambre, lot) {
+async function fetchRows(etage, chambre, lot, start, end) {
   const sql = `
     SELECT user_id, action, lot, floor_id::text AS floor, room_id::text AS room,
            task, status, created_at
@@ -28,8 +28,10 @@ async function fetchRows(etage, chambre, lot) {
       WHERE ($1='' OR floor_id::text=$1)
         AND ($2='' OR room_id::text=$2)
         AND ($3='' OR lot=$3)
+        AND ($4 = '' OR created_at >= $4::date)
+        AND ($5 = '' OR created_at <= $5::date)
       ORDER BY created_at DESC`;
-  const { rows } = await pool.query(sql, [etage, chambre, lot]);
+  const { rows } = await pool.query(sql, [etage, chambre, lot, start, end]);
   return rows;
 }
 
@@ -38,7 +40,9 @@ router.get('/pdf', async (req, res) => {
     const etage = req.query.etage || '';
     const chambre = req.query.chambre || '';
     const lot = req.query.lot || '';
-    const rows = await fetchRows(etage, chambre, lot);
+    const start = req.query.start || '';
+    const end = req.query.end || '';
+    const rows = await fetchRows(etage, chambre, lot, start, end);
     const userMap = loadUsersMap();
 
     const doc = new PDFDocument({ margin: 30, size: 'A4' });
@@ -94,7 +98,9 @@ router.get('/excel', async (req, res) => {
     const etage = req.query.etage || '';
     const chambre = req.query.chambre || '';
     const lot = req.query.lot || '';
-    const rows = await fetchRows(etage, chambre, lot);
+    const start = req.query.start || '';
+    const end = req.query.end || '';
+    const rows = await fetchRows(etage, chambre, lot, start, end);
     const userMap = loadUsersMap();
     const workbook = new ExcelJS.Workbook();
     const sheet = workbook.addWorksheet('Interventions');


### PR DESCRIPTION
## Summary
- add start/end date filters in the history tab
- include these dates in export links
- allow export route to filter by date range

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877abbd105083279edf2c20558573f0