### PR TITLE
Apply inline edit rules and cleanup PATCH route

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -445,21 +445,13 @@ async function loadPhotos() {
 
 async function enableInlineEditing() {
   document.querySelectorAll(
-    'td.editable[data-field="status"], td.editable[data-field="person"]'
+    'td.editable[data-field="status"]'
   ).forEach(td => {
     td.addEventListener('click', async () => {
       const field = td.dataset.field;
       const id = td.closest('tr').dataset.id;
       let options = [];
       if (field === 'status') {
-        const allowedStatuses = [
-          'ouvert',
-          'en_cours',
-          'attente_validation',
-          'clos',
-          'valide',
-          'a_definir'
-        ];
         options = allowedStatuses.map(key => ({ id: key, label: statusLabels[key] }));
       } else {
         options = Object.entries(window.userMap).map(([id, username]) => ({ id, username }));
@@ -487,14 +479,8 @@ async function enableInlineEditing() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ [field]: newVal })
         });
-        td.textContent = field === 'status'
-          ? statusLabels[newVal]
-          : window.userMap[newVal];
-        if (field === 'status') {
-          td.className = `editable ${field}-cell status-${newVal.replace(/\s+/g,'_')}`;
-        } else {
-          td.className = `editable ${field}-cell`;
-        }
+        // relance tout l’historique pour persister l’affichage
+        await loadHistory();
       });
       select.addEventListener('blur', () => { td.textContent = td.textContent; });
     });

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -343,7 +343,10 @@ router.patch('/:id', async (req, res) => {
     const updates = [], values = [];
     let idx = 1;
     for (const [k, v] of Object.entries(req.body)) {
-      updates.push(`${k}=$${idx}`); values.push(v); idx++;
+      // k devrait valoir "status" ou "person"
+      updates.push(`${k}=$${idx}`);
+      values.push(v);
+      idx++;
     }
     values.push(req.params.id);
     await client.query(


### PR DESCRIPTION
## Summary
- align inline editing behaviour with restrictions
- use allowed statuses when switching status
- reload history after patch for display persistence
- document allowed fields in PATCH route
- only status column can be edited inline

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687907e1ac388327a15088ebb22dc88a