### PR TITLE
Fix inline editing refresh

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -479,10 +479,9 @@ async function enableInlineEditing() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ [field]: newVal })
         });
-        // relance tout l’historique pour persister l’affichage
+        // Recharge tout l’historique : l’UI se remet proprement.
         await loadHistory();
       });
-      select.addEventListener('blur', () => { td.textContent = td.textContent; });
     });
   });
 }


### PR DESCRIPTION
## Summary
- reload history immediately after PATCH in inline status editor
- drop blur handler so select disappears after reload
- confirm patch endpoint updates `status` and commits before responding

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687dedaff9f883278a4a5720ecd9a87a