### PR TITLE
Add debug logs for inline edit workflow

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -474,11 +474,13 @@ async function enableInlineEditing() {
       select.focus();
       select.addEventListener('change', async () => {
         const newVal = select.value;
-        await fetch(`/api/interventions/${id}`, {
+        console.log('🛠️ inline edit:', { id, field, newVal });
+        const res = await fetch(`/api/interventions/${id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ [field]: newVal })
         });
+        console.log('🛠️ PATCH response:', res.status, await res.json());
         // Recharge tout l’historique : l’UI se remet proprement.
         await loadHistory();
       });

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -330,6 +330,7 @@ router.put('/:id', async (req, res) => {
 });
 
 router.patch('/:id', async (req, res) => {
+  console.log('🛠️ PATCH /api/interventions/' + req.params.id, req.body);
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
@@ -349,6 +350,7 @@ router.patch('/:id', async (req, res) => {
       idx++;
     }
     values.push(req.params.id);
+    console.log('🛠️ SQL UPDATE:', updates.join(', '), values);
     await client.query(
       `UPDATE interventions SET ${updates.join(', ')} WHERE id=$${idx}`,
       values


### PR DESCRIPTION
## Summary
- log inline edit data and PATCH results in `public/selection.js`
- log incoming PATCH body and computed SQL update in `routes/interventions.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687df397e9008327a8d699b87b810bf1