### PR TITLE
Update inline editing and patch route

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -474,15 +474,24 @@ async function enableInlineEditing() {
       select.focus();
       select.addEventListener('change', async () => {
         const newVal = select.value;
-        console.log('🛠️ inline edit:', { id, field, newVal });
+        // 1️⃣ on pousse la mise à jour vers le serveur
         const res = await fetch(`/api/interventions/${id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ [field]: newVal })
+          body: JSON.stringify({ status: newVal })
         });
-        console.log('🛠️ PATCH response:', res.status, await res.json());
-        // Recharge tout l’historique : l’UI se remet proprement.
-        await loadHistory();
+        if (!res.ok) {
+          console.error('PATCH failed', res.status);
+          // si échec, on recharge pour repasser au statut d’avant
+          return loadHistory();
+        }
+
+        // 2️⃣ on met à jour la cellule tout de suite
+        td.textContent = statusLabels[newVal];
+        td.className = `status-cell editable status-${newVal.replace(/\s+/g,'_')}`;
+
+        // 3️⃣ (optionnel) on peut recharger en arrière‐plan pour tout synchroniser
+        loadHistory();
       });
     });
   });

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -330,68 +330,28 @@ router.put('/:id', async (req, res) => {
 });
 
 router.patch('/:id', async (req, res) => {
-  console.log('🛠️ PATCH /api/interventions/' + req.params.id, req.body);
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    // 1) before
+    // 1) lire l'ancien
     const before = (await client.query(
-      'SELECT lot, task, status, person, floor_id, room_id FROM interventions WHERE id=$1',
+      'SELECT status FROM interventions WHERE id=$1',
       [req.params.id]
     )).rows[0];
 
-    // 2) update générique
-    const updates = [], values = [];
-    let idx = 1;
-    for (const [k, v] of Object.entries(req.body)) {
-      // k devrait valoir "status" ou "person"
-      updates.push(`${k}=$${idx}`);
-      values.push(v);
-      idx++;
-    }
-    values.push(req.params.id);
-    console.log('🛠️ SQL UPDATE:', updates.join(', '), values);
+    // 2) appliquer la mise à jour
     await client.query(
-      `UPDATE interventions SET ${updates.join(', ')} WHERE id=$${idx}`,
-      values
+      'UPDATE interventions SET status=$1 WHERE id=$2',
+      [req.body.status, req.params.id]
     );
 
-    // 3) after
-    const after = (await client.query(
-      'SELECT lot, task, status, person, floor_id, room_id FROM interventions WHERE id=$1',
-      [req.params.id]
-    )).rows[0];
-
-    // 4) historisation
+    // 3) historiser
+    const after = req.body.status;
     await client.query(
       `INSERT INTO interventions_history
-         (intervention_id, user_id,
-          lot_old, lot_new,
-          task_old, task_new,
-          state_old, state_new,
-          floor_old, floor_new,
-          room_old, room_new,
-          person_old, person_new,
-          action)
-       VALUES
-         ($1, $2,
-          $3,  $4,
-          $5,  $6,
-          $7,  $8,
-          $9,  $10,
-          $11, $12,
-          $13, $14,
-          'Modification')`,
-      [
-        req.params.id,
-        req.session.user?.id || '',
-        before.lot, after.lot,
-        before.task, after.task,
-        before.status, after.status,
-        before.floor_id, after.floor_id,
-        before.room_id, after.room_id,
-        before.person, after.person
-      ]
+         (intervention_id, user_id, state_old, state_new, action)
+       VALUES ($1, $2, $3, $4, 'Modification')`,
+      [req.params.id, req.session.user?.id || '', before.status, after]
     );
 
     await client.query('COMMIT');


### PR DESCRIPTION
## Summary
- update inline editing event handler to update cell immediately after saving
- simplify PATCH route for interventions to handle status only

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687df67cab80832781e90faf03cebdbd