### PR TITLE
Fix history refresh and mobile modal

### DIFF
--- a/public/selection.css
+++ b/public/selection.css
@@ -117,6 +117,7 @@ button:focus {
 }
 
 .modal-dialog {
+  position: relative;
   background: #fff;
   padding: 1rem;
   border-radius: 4px;
@@ -130,6 +131,16 @@ button:focus {
   border: none;
   background: transparent;
   font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.close-history {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
   cursor: pointer;
 }
 
@@ -209,7 +220,7 @@ button:focus {
 
 .history-table td.changed {
   background-color: #ffecec;
-  font-weight: 600;
+  font-weight: bold;
 }
 
 /* Conteneur responsive pour les tableaux */

--- a/public/selection.js
+++ b/public/selection.js
@@ -63,12 +63,12 @@ function showTaskHistory(logs) {
     .map(l => `
       <tr class="${l.action === 'Création' ? 'creation' : 'modification'}">
         <td>${new Date(l.created_at).toLocaleString()}</td>
-        <td class="${mark(l.person_old, l.person_new)}">${window.userMap[l.person_old] || l.person_old || '–'}</td><td>${window.userMap[l.person_new] || l.person_new || '–'}</td>
-        <td class="${mark(l.floor_old, l.floor_new)}">${l.floor_old || '–'}</td><td>${l.floor_new || '–'}</td>
-        <td class="${mark(l.room_old, l.room_new)}">${l.room_old  || '–'}</td><td>${l.room_new  || '–'}</td>
-        <td class="${mark(l.lot_old, l.lot_new)}">${l.lot_old   || '–'}</td><td>${l.lot_new   || '–'}</td>
-        <td class="${mark(l.task_old, l.task_new)}">${l.task_old  || '–'}</td><td>${l.task_new  || '–'}</td>
-        <td class="${mark(l.state_old, l.state_new)}">${l.state_old || '–'}</td><td>${l.state_new || '–'}</td>
+        <td class="${mark(l.person_old, l.person_new)}">${window.userMap[l.person_old] || l.person_old || '–'}</td><td class="${mark(l.person_old, l.person_new)}">${mark(l.person_old, l.person_new) === 'changed' ? `<strong>${window.userMap[l.person_new] || l.person_new || '–'}</strong>` : (window.userMap[l.person_new] || l.person_new || '–')}</td>
+        <td class="${mark(l.floor_old, l.floor_new)}">${l.floor_old || '–'}</td><td class="${mark(l.floor_old, l.floor_new)}">${mark(l.floor_old, l.floor_new) === 'changed' ? `<strong>${l.floor_new || '–'}</strong>` : (l.floor_new || '–')}</td>
+        <td class="${mark(l.room_old, l.room_new)}">${l.room_old  || '–'}</td><td class="${mark(l.room_old, l.room_new)}">${mark(l.room_old, l.room_new) === 'changed' ? `<strong>${l.room_new  || '–'}</strong>` : (l.room_new  || '–')}</td>
+        <td class="${mark(l.lot_old, l.lot_new)}">${l.lot_old   || '–'}</td><td class="${mark(l.lot_old, l.lot_new)}">${mark(l.lot_old, l.lot_new) === 'changed' ? `<strong>${l.lot_new   || '–'}</strong>` : (l.lot_new   || '–')}</td>
+        <td class="${mark(l.task_old, l.task_new)}">${l.task_old  || '–'}</td><td class="${mark(l.task_old, l.task_new)}">${mark(l.task_old, l.task_new) === 'changed' ? `<strong>${l.task_new  || '–'}</strong>` : (l.task_new  || '–')}</td>
+        <td class="${mark(l.state_old, l.state_new)}">${l.state_old || '–'}</td><td class="${mark(l.state_old, l.state_new)}">${mark(l.state_old, l.state_new) === 'changed' ? `<strong>${l.state_new || '–'}</strong>` : (l.state_new || '–')}</td>
         <td>${l.action}</td>
       </tr>
     `)
@@ -90,6 +90,14 @@ function showTaskHistory(logs) {
         <tbody>${rows}</tbody>
       </table>
     `;
+  // ajoute un bouton de fermeture si pas déjà présent
+  if (!modal.querySelector('.close-history')) {
+    const btn = document.createElement('button');
+    btn.textContent = '✕';
+    btn.className = 'close-history';
+    btn.addEventListener('click', () => modal.hidden = true);
+    modal.prepend(btn);
+  }
   modal.hidden = false;
 }
 
@@ -322,11 +330,11 @@ async function enableInlineEditing() {
         });
         if (!res.ok) {
           console.error('PATCH failed', res.status);
-          return loadHistory();
+          return await loadHistory();
         }
         td.textContent = statusLabels[newVal];
         td.className   = `status-cell editable status-${newVal.replace(/\s+/g,'_')}`;
-        loadHistory();
+        await loadHistory();
       });
     });
   });


### PR DESCRIPTION
## Summary
- await `loadHistory` after patching tasks so the UI shows updated state
- highlight new values in task history when changed
- add close button dynamically in history modal and style it for mobile
- mark changed table cells bold

## Testing
- `node server.js` *(fails: Cannot find module 'cloudinary')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e05ed5ef08327a1e6f55184263387