### PR TITLE
Ajout de l’édition rapide du statut

### DIFF
--- a/public/selection.css
+++ b/public/selection.css
@@ -136,12 +136,13 @@ button:focus {
 
 .close-history {
   position: absolute;
-  top: 0.25rem;
-  right: 0.25rem;
-  border: none;
-  background: transparent;
+  top: 8px;
+  right: 8px;
   font-size: 1.5rem;
+  background: none;
+  border: none;
   cursor: pointer;
+  z-index: 10;
 }
 
 .info-cell {

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -273,71 +273,7 @@ router.post('/:id/comment', async (req, res) => {
   res.json({ success: true });
 });
 
-router.patch('/:id', async (req, res) => {
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-
-    const before = (await client.query(
-      `SELECT lot, task, status, person, floor_id, room_id
-         FROM interventions
-        WHERE id = $1`,
-      [req.params.id]
-    )).rows[0];
-
-    await client.query(
-      `UPDATE interventions
-          SET status = $1,
-              action = 'Modification'
-        WHERE id = $2`,
-      // on récupère “state” côté JSON
-      [req.body.state, req.params.id]
-    );
-
-    await client.query(
-      `INSERT INTO interventions_history
-         (intervention_id, user_id,
-          lot_old,    lot_new,
-          task_old,   task_new,
-          state_old,  state_new,
-          floor_old,  floor_new,
-          room_old,   room_new,
-          person_old, person_new,
-          action,     created_at)
-       VALUES
-         ($1, $2,
-          $3, $4,
-          $5, $6,
-          $7, $8,
-          $9, $10,
-          $11, $12,
-          $13, $14,
-          'Modification', now())`,
-      [
-        req.params.id,
-        req.session.user?.id || '',
-        before.lot,    before.lot,
-        before.task,   before.task,
-        before.status, req.body.state,
-        before.floor_id, before.floor_id,
-        before.room_id,  before.room_id,
-        before.person,   before.person
-      ]
-    );
-
-    await client.query('COMMIT');
-    res.json({ success: true });
-  } catch (err) {
-    await client.query('ROLLBACK');
-    console.error(err);
-    res.status(500).json({ error: 'Erreur serveur modification' });
-  } finally {
-    client.release();
-  }
-});
-
-// PUT update an intervention
-router.put('/:id', async (req, res) => {
+ router.put('/:id', async (req, res) => {
   const { floor, room, lot, task, person, state, userId } = req.body;
   try {
     // 1️⃣ lire l’état courant
@@ -450,6 +386,70 @@ router.post('/bulk', async (req, res) => {
   }
 });
 
+// PATCH /api/interventions/:id — met à jour juste le status et historise TOUTES les colonnes
+router.patch('/:id', async (req, res) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    // 1️⃣ On lit l’état complet avant modif
+    const before = (await client.query(
+      `SELECT lot, task, status, person, floor_id, room_id
+         FROM interventions
+        WHERE id=$1`, [req.params.id]
+    )).rows[0];
+
+    // 2️⃣ On update uniquement le status + action
+    await client.query(
+      `UPDATE interventions
+          SET status = $1,
+              action = 'Modification'
+        WHERE id = $2`,
+      [req.body.status, req.params.id]
+    );
+
+    // 3️⃣ On historise exactement comme en PUT
+    await client.query(
+      `INSERT INTO interventions_history
+         (intervention_id, user_id,
+          lot_old,    lot_new,
+          task_old,   task_new,
+          state_old,  state_new,
+          floor_old,  floor_new,
+          room_old,   room_new,
+          person_old, person_new,
+          action,     created_at)
+       VALUES
+         ($1, $2,
+          $3, $4,
+          $5, $6,
+          $7, $8,
+          $9, $10,
+          $11, $12,
+          $13, $14,
+          'Modification', now())`,
+      [
+        req.params.id,
+        req.session.user?.id || '',
+        before.lot,    before.lot,
+        before.task,   before.task,
+        before.status, req.body.status,
+        before.floor_id, before.floor_id,
+        before.room_id,  before.room_id,
+        before.person,   before.person
+      ]
+    );
+
+    await client.query('COMMIT');
+    res.json({ success: true });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur modification' });
+  } finally {
+    client.release();
+  }
+});
 router.post('/:id/photos', upload.array('photos'), async (req, res) => {
   const urls = req.files.map(f => f.path);
   // persister en base et attendre chaque insertion


### PR DESCRIPTION
## Résumé
- ajout d’une route `PATCH /api/interventions/:id` pour modifier uniquement l’état
- réactivation de l’édition inline dans `selection.js`
- mise en gras des valeurs modifiées dans l’historique et bouton de fermeture mobile

## Tests
- `node --check routes/interventions.js`
- `node --check public/selection.js`
- `npm test` *(échoue : `Missing script: "test"`)*

------
https://chatgpt.com/codex/tasks/task_e_687e08e0e4b88327bcd72596446a5d52