### PR TITLE
Fix patch history user

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -432,7 +432,7 @@ router.patch('/:id', async (req, res) => {
           'Modification', now())`,
       [
         req.params.id,
-        req.session.user?.id || '',
+        before.person,
         before.lot,    before.lot,
         before.task,   before.task,
         before.status, req.body.status,


### PR DESCRIPTION
## Summary
- fix `PATCH /api/interventions/:id` history logic by using the existing assigned person

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e43e11b58832783fed8bc8352c9bb