### PR TITLE
Add state filter and export modal

### DIFF
--- a/public/selection.html
+++ b/public/selection.html
@@ -39,6 +39,17 @@
         <option value="Repose">Repose</option>
       </select>
     </label>
+    <label>État
+      <select id="hist-state">
+        <option value="">-- Tous les états --</option>
+        <option value="ouvert">Ouvert</option>
+        <option value="en_cours">En cours</option>
+        <option value="attente_validation">En attente de validation</option>
+        <option value="clos">Clos</option>
+        <option value="valide">Validé</option>
+        <option value="a_definir">À définir</option>
+      </select>
+    </label>
     <label>Du
       <input type="date" id="date-start">
     </label>
@@ -46,8 +57,28 @@
       <input type="date" id="date-end">
     </label>
     <button id="hist-refresh">Rafraîchir</button>
-    <button id="export-pdf">Exporter PDF</button>
-    <button id="export-excel">Exporter Excel</button>
+    <button id="export-config" class="btn">Export ▾</button>
+    <div id="export-modal" class="modal" hidden>
+      <div class="modal-dialog">
+        <h3>Exporter</h3>
+        <label><input type="checkbox" value="id" checked> ID</label>
+        <label><input type="checkbox" value="user_id" checked> Utilisateur</label>
+        <label><input type="checkbox" value="action" checked> Action</label>
+        <label><input type="checkbox" value="lot" checked> Lot</label>
+        <label><input type="checkbox" value="floor_id" checked> Étage</label>
+        <label><input type="checkbox" value="room_id" checked> Chambre</label>
+        <label><input type="checkbox" value="task" checked> Tâche</label>
+        <label><input type="checkbox" value="status" checked> État</label>
+        <label><input type="checkbox" value="person" checked> Personne</label>
+        <label><input type="checkbox" value="created_at" checked> Date</label>
+        <hr>
+        <label><input type="radio" name="format" value="csv" checked> CSV</label>
+        <label><input type="radio" name="format" value="pdf"> PDF</label>
+        <label><input type="radio" name="format" value="excel"> Excel</label>
+        <button id="export-go">Télécharger</button>
+        <button class="close-history">✕</button>
+      </div>
+    </div>
     <div class="table-container">
     <table id="history-table" class="data-table">
       <thead>

--- a/public/selection.js
+++ b/public/selection.js
@@ -178,9 +178,10 @@ async function loadHistory() {
   const params = new URLSearchParams({
     etage: document.getElementById('hist-floor').value || '',
     chambre: document.getElementById('hist-room').value || '',
-    lot: document.getElementById('hist-lot').value || '',
-    start: document.getElementById('date-start').value || '',
-    end:   document.getElementById('date-end').value || ''
+    lot:    document.getElementById('hist-lot').value || '',
+    state:  document.getElementById('hist-state').value || '',
+    start:  document.getElementById('date-start').value || '',
+    end:    document.getElementById('date-end').value || ''
   });
   console.log('⚙️ HISTORY SQL params:', params.toString());
   const res = await fetch('/api/interventions/history?' + params.toString());
@@ -534,28 +535,35 @@ window.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('edit-room').addEventListener('change', loadPreview);
   document.getElementById('edit-lot').addEventListener('change', loadPreview);
   document.getElementById('hist-floor').addEventListener('change', e => loadRooms(e.target.value, '#hist-room'));
+  document.getElementById('hist-state').addEventListener('change', loadHistory);
   document.getElementById('edit-floor').addEventListener('change', e => loadRooms(e.target.value, '#edit-room'));
   document.getElementById('hist-refresh').addEventListener('click', loadHistory);
-  document.getElementById('export-pdf').addEventListener('click', () => {
+  // ouverture du modal d’export
+  document.getElementById('export-config').onclick = () => {
+    document.getElementById('export-modal').hidden = false;
+  };
+  // fermeture
+  document.querySelector('#export-modal .close-history').onclick = () => {
+    document.getElementById('export-modal').hidden = true;
+  };
+  // lancement export
+  document.getElementById('export-go').onclick = async () => {
+    const cols = Array.from(
+      document.querySelectorAll('#export-modal input[type=checkbox]:checked')
+    ).map(i => i.value).join(',');
+    const fmt = document.querySelector('#export-modal input[name=format]:checked').value;
     const params = new URLSearchParams({
       etage: document.getElementById('hist-floor').value || '',
       chambre: document.getElementById('hist-room').value || '',
       lot: document.getElementById('hist-lot').value || '',
+      state: document.getElementById('hist-state').value || '',
       start: document.getElementById('date-start').value || '',
-      end: document.getElementById('date-end').value || ''
+      end: document.getElementById('date-end').value || '',
+      columns: cols
     });
-    downloadFile('/api/export/pdf?' + params.toString(), 'interventions.pdf');
-  });
-  document.getElementById('export-excel').addEventListener('click', () => {
-    const params = new URLSearchParams({
-      etage: document.getElementById('hist-floor').value || '',
-      chambre: document.getElementById('hist-room').value || '',
-      lot: document.getElementById('hist-lot').value || '',
-      start: document.getElementById('date-start').value || '',
-      end: document.getElementById('date-end').value || ''
-    });
-    downloadFile('/api/export/excel?' + params.toString(), 'interventions.xlsx');
-  });
+    window.location = `/api/export/${fmt}?` + params.toString();
+    document.getElementById('export-modal').hidden = true;
+  };
   document.querySelector('.tabs').addEventListener('click', e => {
     if (e.target.tagName === 'BUTTON') {
       showTab(e.target.dataset.tab);

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -185,7 +185,7 @@ router.get('/export/pdf', async (req, res) => {
 // GET /api/interventions/history?etage=&chambre=&lot=
 router.get('/history', async (req, res) => {
   // on s’assure que ces variables sont toujours des chaînes
-  const { etage='', chambre='', lot='', start='', end='' } = req.query;
+  const { etage='', chambre='', lot='', state='', start='', end='' } = req.query;
 
   const sql = `
     SELECT
@@ -203,15 +203,16 @@ router.get('/history', async (req, res) => {
     WHERE ($1 = '' OR i.floor_id::text = $1)
       AND ($2 = '' OR i.room_id::text  = $2)
       AND ($3 = '' OR i.lot         = $3)
-      AND ($4 = '' OR i.created_at >= $4::timestamp)
-      AND ($5 = '' OR i.created_at <= $5::timestamp)
+      AND ($4 = '' OR i.status = $4::text)
+      AND ($5 = '' OR i.created_at >= $5::timestamp)
+      AND ($6 = '' OR i.created_at <= $6::timestamp)
     ORDER BY i.created_at DESC;
   `;
   console.log('––– HISTORY SQL –––');
   console.log('SQL:', sql.replace(/\s+/g, ' '));
-  console.log('Params:', { etage, chambre, lot, start, end });
+  console.log('Params:', { etage, chambre, lot, state, start, end });
   console.log('–––––––––––––––––––');
-  const { rows } = await pool.query(sql, [etage, chambre, lot, start, end]);
+  const { rows } = await pool.query(sql, [etage, chambre, lot, state, start, end]);
   res.json(rows);
 });
 


### PR DESCRIPTION
## Summary
- support filtering interventions by status
- add configurable export modal on history page
- create single `/api/export/:format` endpoint (csv, pdf, excel)

## Testing
- `node --check routes/export.js`
- `node --check routes/interventions.js`
- `node --check public/selection.js`

------
https://chatgpt.com/codex/tasks/task_e_687f43340b5c832785a3ce600f7877c3