### PR TITLE
Add dynamic chantiers route

### DIFF
--- a/routes/chantiers.js
+++ b/routes/chantiers.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+
+// GET /api/chantiers
+// Renvoie la liste des chantiers depuis la base
+router.get('/', async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT id, name FROM chantiers ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error('Erreur GET /api/chantiers', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const floorsRoutes = require("./routes/floors");
 const roomsRoutes = require("./routes/rooms");
 const exportRoutes = require("./routes/export");
 const commentsRoutes = require("./routes/comments");
+const chantiersRoutes = require('./routes/chantiers');
 const pool = require("./db");
 const { isAuthenticated } = require("./middlewares/auth");
 
@@ -135,6 +136,8 @@ app.use(express.static(path.join(__dirname, "public")));
 
 // Toutes les routes suivantes nécessitent l'authentification
 app.use(isAuthenticated);
+// Route pour récupérer la liste des chantiers
+app.use('/api/chantiers', chantiersRoutes);
 
 // Gestion des interventions (POST + GET /api/interventions)
 app.use('/api/interventions', interventionsRoutes);


### PR DESCRIPTION
## Summary
- connect `/api/chantiers` to the database

## Testing
- `npm start` *(fails: Cannot find module 'cloudinary')*

------
https://chatgpt.com/codex/tasks/task_e_6880a74ef068832786613f4f9083ec5a