### PR TITLE
Fix chantiers route to use column nom

### DIFF
--- a/routes/chantiers.js
+++ b/routes/chantiers.js
@@ -6,7 +6,9 @@ const pool = require('../db');
 // Renvoie la liste des chantiers depuis la base
 router.get('/', async (req, res) => {
   try {
-    const { rows } = await pool.query('SELECT id, name FROM chantiers ORDER BY id');
+    const { rows } = await pool.query(
+      'SELECT id, nom AS name FROM chantiers ORDER BY id'
+    );
     res.json(rows);
   } catch (err) {
     console.error('Erreur GET /api/chantiers', err);


### PR DESCRIPTION
## Summary
- use `nom` column aliased as `name` when listing chantiers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880abcc4ad88327b41750b21c200dc5