### PR TITLE
Fix closePopups button

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -247,6 +247,8 @@ document.addEventListener('DOMContentLoaded', () => {
         p.remove();
       });
     }
+    // rendre la fonction accessible depuis l’attribut onclick inline
+    window.closePopups = closePopups;
 
     function confirmDelete(id) {
       if (!user) {


### PR DESCRIPTION
## Summary
- expose `closePopups` on `window` to allow inline `onclick` handler to work

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6880afa479e88327b550accee54b5e28