### PR TITLE
Fix route ordering for actions

### DIFF
--- a/server.js
+++ b/server.js
@@ -162,8 +162,11 @@ app.use('/api/interventions', interventionsRoutes);
 app.use("/api/users", usersRoutes);
 app.use("/api/floors", floorsRoutes);
 app.use("/api/rooms", roomsRoutes);
-app.use('/api/bulles', bullesRoutes);
+// Monter d'abord la route "actions"
 app.use('/api/bulles/actions', actionsRoutes);
+
+// Puis toutes les autres sous /api/bulles
+app.use('/api/bulles', bullesRoutes);
 app.use('/api/export', exportRoutes);
 app.use('/api/comments', commentsRoutes);
 


### PR DESCRIPTION
## Summary
- ensure `/api/bulles/actions` is registered before `/api/bulles`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6880b92051c883279507ffd1b74497df