### PR TITLE
Améliorations historique bulles

### DIFF
--- a/public/historique.html
+++ b/public/historique.html
@@ -17,8 +17,13 @@
         <tr>
           <th>Utilisateur</th>
           <th>Action</th>
-          <th>Emplacement</th>
-          <th>Bulle</th>
+          <th>Étage</th>
+          <th>Chambre</th>
+          <th>N°</th>
+          <th>Lot</th>
+          <th>Entreprise</th>
+          <th>Localisation</th>
+          <th>Observation</th>
           <th>Description</th>
           <th>Date/Heure</th>
         </tr>

--- a/public/historique.js
+++ b/public/historique.js
@@ -14,17 +14,26 @@ window.addEventListener('DOMContentLoaded', () => {
         actions.forEach(a => {
           const row = document.createElement('tr');
 
-          const emplacement = a.chambre
-            ? `${a.etage} / ${a.chambre}`
-            : `${a.etage} (${Number(a.x).toFixed(2)}, ${Number(a.y).toFixed(2)})`;
+          // n° de bulle
+          const numero = a.nom_bulle.match(/^Bulle (\d+)/)?.[1] || '';
+
+          // user : prefixe avant le premier point de l’email
+          const userLabel = a.user_id
+            ? a.user_id.split('@')[0].split('.')[0]
+            : '';
 
           const values = [
-            a.user_id || a.user,
+            userLabel,
             a.action,
-            emplacement,
-            a.nom_bulle || a.nomBulle || '',
-            a.description || '',
-            new Date(a.created_at || a.timestamp).toLocaleString()
+            a.etage,
+            a.chambre || '',
+            numero,
+            a.lot || '',
+            a.entreprise  || '',
+            a.localisation || '',
+            a.observation || '',
+            a.description  || '',
+            new Date(a.created_at||a.timestamp).toLocaleString()
           ];
           values.forEach(val => {
             const td = document.createElement('td');

--- a/routes/actions.js
+++ b/routes/actions.js
@@ -3,14 +3,18 @@ const pool = require('../db');
 const router = express.Router();
 
 // POST /api/bulles/actions
-// body = { user, action, etage, chambre, x, y, nomBulle, description, timestamp }
+// body = { user, action, etage, chambre, x, y, nomBulle, description,
+//          lot, entreprise, localisation, observation, timestamp }
 router.post('/', async (req, res) => {
   try {
-    const { user, action, etage, chambre, x, y, nomBulle, description, timestamp } = req.body;
+    const {
+      user, action, etage, chambre, x, y, nomBulle, description,
+      lot, entreprise, localisation, observation, timestamp
+    } = req.body;
     await pool.query(
-      `INSERT INTO local_actions (user_id, action, etage, chambre, x, y, nom_bulle, description, created_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
-      [user, action, etage, chambre, x, y, nomBulle, description, timestamp]
+      `INSERT INTO local_actions (user_id, action, etage, chambre, x, y, nom_bulle, description, lot, entreprise, localisation, observation, created_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+      [user, action, etage, chambre, x, y, nomBulle, description, lot, entreprise, localisation, observation, timestamp]
     );
     res.status(201).end();
   } catch (err) {

--- a/server.js
+++ b/server.js
@@ -110,9 +110,17 @@ const { isAuthenticated } = require("./middlewares/auth");
       y REAL,
       nom_bulle TEXT,
       description TEXT,
+      lot TEXT,
+      entreprise TEXT,
+      localisation TEXT,
+      observation TEXT,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     );
   `);
+  await pool.query("ALTER TABLE local_actions ADD COLUMN IF NOT EXISTS lot TEXT");
+  await pool.query("ALTER TABLE local_actions ADD COLUMN IF NOT EXISTS entreprise TEXT");
+  await pool.query("ALTER TABLE local_actions ADD COLUMN IF NOT EXISTS localisation TEXT");
+  await pool.query("ALTER TABLE local_actions ADD COLUMN IF NOT EXISTS observation TEXT");
 })().catch(console.error);
 
 const app = express();


### PR DESCRIPTION
## Summary
- améliorer l’affichage de l’historique et toutes les colonnes
- rétablir l’incrément global des numéros de bulle
- enregistrer dans l’historique le numéro et les infos complètes
- mettre à jour la route `/api/bulles/actions` et la table correspondante

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880bb4eb3f48327a05551b83c4aec8f