### PR TITLE
Use database for floors

### DIFF
--- a/routes/floors.js
+++ b/routes/floors.js
@@ -1,14 +1,19 @@
 const express = require('express');
 const router = express.Router();
+const pool = require('../db');
 
 // GET /api/floors
-// Renvoie une liste statique d'étages R+0 à R+5
-router.get('/', (req, res) => {
-  const floors = Array.from({ length: 6 }, (_, i) => {
-    const name = `R+${i}`;
-    return { id: name, name };
-  });
-  res.json(floors);
+// Renvoie la liste des étages depuis la table `floors`
+router.get('/', async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      'SELECT id, name FROM floors ORDER BY id'
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('Erreur GET /api/floors', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- switch `/api/floors` route to query the DB instead of returning static data

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880cc48b4d4832789d922a7e01db003