### PR TITLE
Switch CSV export from csv-express to json2csv

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "cloudinary": "^1.37.2",
     "multer-storage-cloudinary": "^4.0.0",
     "exceljs": "^4.3.0",
-    "pdfkit": "^0.13.0",
-    "csv-express": "^1.1.1"
+    "pdfkit": "^0.13.0"
   }
 }

--- a/routes/export.js
+++ b/routes/export.js
@@ -4,12 +4,9 @@ const pool = require('../db');
 const PDFDocument = require('pdfkit');
 const ExcelJS = require('exceljs');
 const { Parser } = require('json2csv');
-const csvExpress = require('csv-express');
 const fs = require('fs');
 const path = require('path');
 
-// expose res.csv()
-router.use(csvExpress());
 
 function loadUsersMap() {
   const csvPath = path.join(__dirname, '../db/users.csv');
@@ -83,8 +80,14 @@ router.get('/', async (req, res) => {
       return;
     }
     default: {
-      res.setHeader('Content-Disposition', 'attachment; filename=bulles.csv');
-      res.csv(rows, true);
+      // CSV via json2csv
+      const parser = new Parser({ fields: cols });
+      let csv = parser.parse(rows);
+      // ajoute BOM pour Excel
+      csv = '\uFEFF' + csv;
+      res.header('Content-Type', 'text/csv; charset=utf-8');
+      res.attachment('bulles.csv');
+      return res.send(csv);
     }
   }
 });  // ← fermeture du router.get


### PR DESCRIPTION
## Summary
- remove deprecated `csv-express` dependency
- implement CSV export with `json2csv`

## Testing
- `node --check routes/export.js`
- `npm ls csv-express`


------
https://chatgpt.com/codex/tasks/task_e_688119d956d08327a7b0ed64ffff72cc