### PR TITLE
Fix floor ID usage and compact export UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,8 +33,9 @@
     </label>
 
     <label>Étage :
-      <select id="etageSelect" data-etage="R+5">
-        <option value="R+5">R+5</option>
+      <select id="etageSelect">
+        <!-- l'ID numérique est stocké dans data-floor-id -->
+        <option value="R+5" data-floor-id="5">R+5</option>
         <!-- etc. -->
       </select>
     </label>

--- a/public/script.js
+++ b/public/script.js
@@ -63,9 +63,12 @@ document.addEventListener('DOMContentLoaded', () => {
           { credentials: 'include' }
         );
         const floors = await res.json();
-        etageSelect.innerHTML = floors.map(f => `<option value="${f.id}">${f.name}</option>`).join('');
-        etageSelect.value = floors[0]?.id || '';
-        await updateRoomOptions(etageSelect.value);
+        etageSelect.innerHTML = floors.map(f =>
+          `<option value="${f.name}" data-floor-id="${f.id}">${f.name}</option>`
+        ).join('');
+        etageSelect.value = floors[0]?.name || '';
+        const floorId = etageSelect.selectedOptions[0]?.dataset.floorId;
+        await updateRoomOptions(floorId);
         changePlan(etageSelect.value);
         loadBulles();
       } catch (err) {
@@ -77,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chambreSelect.dataset.etage = floorId;
       try {
         const res = await fetch(
-          `/api/rooms?floor_id=${encodeURIComponent(floorId)}`,
+          `/api/rooms?floor_id=${floorId}`,
           { credentials: 'include' }
         );
         if (!res.ok) throw new Error(`Status ${res.status}`);
@@ -537,7 +540,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     chantierSelect.onchange = () => updateFloorOptions(chantierSelect.value);
-    etageSelect.onchange = () => { changePlan(etageSelect.value); updateRoomOptions(etageSelect.value); loadBulles(); };
+    etageSelect.onchange = () => {
+      const floorId = etageSelect.selectedOptions[0]?.dataset.floorId;
+      changePlan(etageSelect.value);
+      updateRoomOptions(floorId);
+      loadBulles();
+    };
     chambreSelect.onchange = loadBulles;
     exportBtn.onclick = () => {
       const etage   = etageSelect.value;

--- a/public/styles.css
+++ b/public/styles.css
@@ -26,6 +26,17 @@ label {
   margin-top: 30px;
 }
 
+#export-columns {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5em 2em;
+}
+
+#export-columns label {
+  display: flex;
+  align-items: center;
+}
+
 select,
 input[type="text"],
 textarea,


### PR DESCRIPTION
## Summary
- store numeric floor IDs in option data attribute in `index.html`
- fetch rooms using integer ID in `script.js`
- read floor ID from option dataset on change
- display export columns in a two-column grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68811c1816e88327b30aacd305a998f9