### PR TITLE
Fix export columns and floor parsing

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -548,7 +548,8 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     chambreSelect.onchange = loadBulles;
     exportBtn.onclick = () => {
-      const etage   = etageSelect.value;
+      // on extrait juste le nombre : "R+3" → 3
+      const etage   = parseInt(etageSelect.value.replace(/^R\+?/, ''), 10);
       const chambre = chambreSelect.value;
       const format  = formatSelect.value; // csv, xlsx ou pdf
 

--- a/routes/export.js
+++ b/routes/export.js
@@ -7,7 +7,7 @@ router.get('/', async (req, res) => {
   const { etage = '', chambre = '', format = 'csv', columns } = req.query;
   // Colonnes par défaut exactement celles de la table `bulles`
   const cols = (columns ||
-    'id,numero,intitule,description,etat,lot,entreprise,localisation,observation,date_butoir,created_at,created_by,etage,chambre'
+    'id,etage,chambre,numero,intitule,description,etat,lot,entreprise,localisation,observation,date_butoir,photo,created_by,modified_by,levee_par,entreprise_id,chantier_id'
   )
     .split(',')
     .map(c => c.trim())
@@ -19,7 +19,7 @@ router.get('/', async (req, res) => {
   if (chambre && chambre !== 'total') { params.push(chambre); conds.push(`chambre = $${params.length}`); }
   const where = conds.length ? 'WHERE ' + conds.join(' AND ') : '';
   // Exécution
-  const sql = `SELECT ${cols.join(', ')} FROM bulles ${where} ORDER BY created_at`;
+  const sql = `SELECT ${cols.join(', ')} FROM bulles ${where} ORDER BY id`;
   const { rows } = await pool.query(sql, params);
 
   // CSV via json2csv


### PR DESCRIPTION
## Summary
- correct selected columns in export route
- sort export by ID instead of `created_at`
- ensure export sends numeric floor value

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68814051bae08327b7d1ebc8c9e04104