### PR TITLE
Fix floor id parsing and export query

### DIFF
--- a/routes/export.js
+++ b/routes/export.js
@@ -23,12 +23,12 @@ router.get('/', async (req, res) => {
   }
   const where = conds.length ? 'WHERE ' + conds.join(' AND ') : '';
 
-  // Récupérer * toutes * les colonnes avec info create/modify
+  // Récupérer * toutes * les colonnes et remonter les emails de créateur/modificateur
   const sql = `
     SELECT
       b.*,
-      u1.email  AS created_by_email,
-      u2.email  AS modified_by_email
+      u1.email AS created_by_email,
+      u2.email AS modified_by_email
     FROM bulles b
     LEFT JOIN interventions_history h
       ON h.intervention_id = b.id

--- a/routes/rooms.js
+++ b/routes/rooms.js
@@ -4,7 +4,9 @@ const pool = require("../db");
 
 // GET /api/rooms
 router.get('/', async (req, res) => {
-  const floorId = req.query.floor_id;
+  // s’assurer d’avoir toujours un entier
+  const raw = req.query.floor_id || '';
+  const floorId = parseInt(raw.replace(/\D/g, ''), 10) || 0;
   // requête SQL qui filtre bien sur la colonne floor_id
   try {
     const { rows } = await pool.query(


### PR DESCRIPTION
## Summary
- ensure `floor_id` is always parsed as an integer in rooms endpoint
- clarify export SQL query comment and spacing for user emails

## Testing
- `node -c routes/rooms.js`
- `node -c routes/export.js`


------
https://chatgpt.com/codex/tasks/task_e_6881ef4255a0832790c18fe4de921da6