### PR TITLE
Fix export filtering by floor label

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -543,10 +543,15 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     chambreSelect.onchange = loadBulles;
     exportBtn.onclick = () => {
-      const floorId = etageSelect.selectedOptions[0].dataset.floorId;
+      const floorLabel = etageSelect.value;      // "R+5"
       const roomId  = chambreSelect.value;       // “total” ou un ID
       const format  = formatSelect.value;        // csv, xlsx ou pdf
-      const params = new URLSearchParams({ floor_id: floorId, room_id: roomId, format });
+
+      const params = new URLSearchParams({
+        floor_id: floorLabel,
+        room_id:  roomId,
+        format
+      });
       window.open(`/api/bulles/export?${params}`, '_blank');
     };
 

--- a/routes/export.js
+++ b/routes/export.js
@@ -6,18 +6,16 @@ const ExcelJS = require('exceljs');
 const PDFDocument = require('pdfkit');
 
 router.get('/', async (req, res) => {
-  // Récupérer et forcer des entiers pour éviter integer = text
-  const rawFloor = req.query.floor_id || '';
+  // on récupère la chaîne "R+X" pour filtrer sur la colonne textuelle `etage`
+  const etageFilter = req.query.floor_id || '';
   const rawRoom  = req.query.room_id  || '';
-  const floorId = parseInt(rawFloor.replace(/\D/g,''), 10);
   const roomId  = parseInt(rawRoom.replace(/\D/g,''), 10);
 
   // Construire WHERE
   const params = [];
   const conds  = [];
-  // On ne pousse le paramètre que s'il est un entier valide
-  if (!isNaN(floorId)) {
-    params.push(floorId);
+  if (etageFilter) {
+    params.push(etageFilter);
     conds.push(`etage = $${params.length}`);
   }
   if (!isNaN(roomId)) {


### PR DESCRIPTION
## Summary
- filter floor by text label instead of numeric ID in export route
- send "R+X" label for floor when exporting from the frontend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6881f81e1bf08327b772f15a44026ba4