### PR TITLE
Exclude ID columns from exports

### DIFF
--- a/routes/export.js
+++ b/routes/export.js
@@ -39,7 +39,9 @@ router.get('/', async (req, res) => {
   const { rows } = await pool.query(sql, params);
 
   // On extrait dynamiquement les noms de colonnes
-  const cols = rows.length > 0 ? Object.keys(rows[0]) : [];
+  let cols = rows.length > 0 ? Object.keys(rows[0]) : [];
+  // On retire les champs numériques qui ne nous intéressent plus
+  cols = cols.filter(c => c !== 'created_by' && c !== 'modified_by');
 
   const format = (req.query.format || 'csv').toLowerCase();
   if (format === 'csv') {


### PR DESCRIPTION
## Summary
- filter out `created_by` and `modified_by` columns in the export route so only the email fields remain

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882010bcf5c83278696fd9faef12824