### PR TITLE
Add title and state columns to history

### DIFF
--- a/public/historique.html
+++ b/public/historique.html
@@ -17,6 +17,7 @@
         <tr>
           <th>Utilisateur</th>
           <th>Action</th>
+          <th>Intitulé</th>
           <th>État</th>
           <th>Étage</th>
           <th>Chambre</th>

--- a/public/historique.js
+++ b/public/historique.js
@@ -1,9 +1,9 @@
 window.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
-  fetch('/api/bulles/actions', { credentials: 'include' })
-    .then(res => res.json())
-    .then(actions => {
-      if (actions.length === 0) {
+  fetch('/api/history', { credentials: 'include' })
+    .then(r => r.json())
+    .then(rows => {
+      if (rows.length === 0) {
         const row = document.createElement('tr');
         const cell = document.createElement('td');
         cell.colSpan = 6;
@@ -11,38 +11,23 @@ window.addEventListener('DOMContentLoaded', () => {
         row.appendChild(cell);
         tbody.appendChild(row);
       } else {
-        actions.forEach(a => {
-          const row = document.createElement('tr');
-
-          // n° de bulle
-          const numero = a.nom_bulle.match(/^Bulle (\d+)/)?.[1] || '';
-
-          // user : prefixe avant le premier point de l’email
-          const userLabel = (a.user || a.user_id || '')
-            .split('@')[0]
-            .split('.')[0];
-
-          const values = [
-            userLabel,
-            a.action,
-            a.etat || '',
-            a.etage,
-            a.chambre || '',
-            numero,
-            a.lot || '',
-            a.entreprise  || '',
-            a.localisation || '',
-            a.observation || '',
-            a.description  || '',
-            new Date(a.created_at||a.timestamp).toLocaleString()
-          ];
-          values.forEach(val => {
-            const td = document.createElement('td');
-            td.textContent = val;
-            row.appendChild(td);
-          });
-          tbody.appendChild(row);
-        });
+        tbody.innerHTML = rows.map(data => `
+          <tr>
+            <td>${data.username}</td>
+            <td>${data.action_type}</td>
+            <td>${data.intitule || ''}</td>
+            <td>${data.etat || ''}</td>
+            <td>${data.etage}</td>
+            <td>${data.chambre}</td>
+            <td>${data.bulle_numero}</td>
+            <td>${data.lot}</td>
+            <td>${data.entreprise || ''}</td>
+            <td>${data.localisation || ''}</td>
+            <td>${data.observation || ''}</td>
+            <td>${data.description || ''}</td>
+            <td>${new Date(data.created_at).toLocaleString()}</td>
+          </tr>
+        `).join('');
       }
     })
     .catch(err => {

--- a/routes/history.js
+++ b/routes/history.js
@@ -20,11 +20,24 @@ router.get('/', async (req, res) => {
   }
   try {
     const result = await pool.query(
-      `SELECT rh.*, u.username, f.name AS etage, b.chambre, b.lot, b.numero AS bulle_numero
+      `SELECT
+         rh.*,
+         u.username,
+         b.etat,
+         b.intitule   AS intitule,
+         f.name      AS etage,
+         b.chambre,
+         b.lot,
+         b.numero    AS bulle_numero,
+         e.nom       AS entreprise,
+         b.localisation,
+         b.observation,
+         b.description
        FROM reserve_history rh
-       JOIN bulles b ON b.id = rh.bulle_id
+       JOIN bulles b   ON b.id = rh.bulle_id
        LEFT JOIN floors f ON b.etage_id = f.id
-       JOIN users u ON u.id = rh.user_id
+       LEFT JOIN entreprises e ON b.entreprise_id = e.id
+       JOIN users u    ON u.id = rh.user_id
        WHERE ${where}
        ORDER BY rh.created_at DESC`,
       params


### PR DESCRIPTION
## Summary
- return bulle status and title in history route
- display *Intitulé* column in historic table
- show values from `/api/history` including `intitule` and `etat`
- include entreprise, localisation, observation and description fields in history API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887251096c48327bc3912ac2d63e95b