### PR TITLE
Use email as username in history

### DIFF
--- a/routes/history.js
+++ b/routes/history.js
@@ -22,7 +22,7 @@ router.get('/', async (req, res) => {
     const result = await pool.query(
       `SELECT
          rh.*,
-         u.username,
+        u.email       AS username,
          b.etat,
          b.intitule   AS intitule,
          f.name      AS etage,


### PR DESCRIPTION
## Summary
- show the user's email in the history query

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_6887312686388327bd8bc201a1200bae