### PR TITLE
Restore author data in comment feed

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -129,9 +129,9 @@ function downloadFile(url, filename) {
 async function loadUsers() {
   const res = await fetch('/api/users', { credentials: 'include' });
   const users = await res.json();
-  window.userMap = users.reduce((m, u) => (m[u.id] = u.email,   m), {});
+  window.userMap = users.reduce((m, u) => (m[u.id] = u.username,   m), {});
   userOptions = '<option value="">--Choisir--</option>' +
-    users.map(u => `<option value="${u.id}">${u.email}</option>`).join('');
+    users.map(u => `<option value="${u.id}">${u.username}</option>`).join('');
   document.querySelectorAll('select.person').forEach(sel => {
     const v = sel.value;
     sel.innerHTML = userOptions;
@@ -145,7 +145,7 @@ async function loadCommentUsers() {
   const select = document.getElementById('comment-user');
   if (!select) return;
   select.innerHTML = '<option value="">Anonyme</option>' +
-    users.map(u => `<option value="${u.id}">${u.email}</option>`).join('');
+    users.map(u => `<option value="${u.id}">${u.username}</option>`).join('');
 }
 
 async function loadFloors(selector) {
@@ -551,16 +551,16 @@ window.addEventListener('DOMContentLoaded', async () => {
     document.querySelector('#edit-table tbody').innerHTML = '';
     addEditRow();
   });
+  await loadFloors('#hist-floor');
+  await loadFloors('#edit-floor');
+  await loadRooms(document.getElementById('hist-floor').value, '#hist-room');
+  await loadRooms(document.getElementById('edit-floor').value, '#edit-room');
   await loadUsers();
   await loadCommentUsers();
-  await loadFloors('#hist-floor');
-  await loadRooms(document.getElementById('hist-floor').value, '#hist-room');
   const histLot = document.getElementById('hist-lot');
   histLot.insertAdjacentHTML('afterbegin',
     '<option value="">-- Tous les lots --</option>'
   );
-  await loadFloors('#edit-floor');
-  await loadRooms(document.getElementById('edit-floor').value, '#edit-room');
   editSubmitBtn.dataset.id = '';
   // Afficher d'emblée l'Historique
   showTab('historyTab');

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -246,11 +246,23 @@ router.get('/:id/history', async (req, res) => {
 });
 
 router.get('/:id/comments', async (req, res) => {
-  const { rows } = await pool.query(
-    'SELECT text, created_at FROM interventions_comments WHERE intervention_id=$1 ORDER BY created_at DESC',
-    [req.params.id]
-  );
-  res.json(rows);
+  try {
+    const { rows } = await pool.query(
+      `SELECT
+         ic.text,
+         ic.created_at,
+         u.email AS username
+       FROM interventions_comments ic
+       LEFT JOIN users u ON u.id = ic.user_id
+       WHERE ic.intervention_id = $1
+       ORDER BY ic.created_at DESC`,
+      [req.params.id]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
 });
 
 router.get('/:id/photos', async (req, res) => {


### PR DESCRIPTION
## Summary
- join `users` when listing comments so each comment includes a username
- keep username alias in client-side user loading
- ensure floors and rooms load first during startup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887788daf548327ab05576253d6d333