### PR TITLE
Support room and floor IDs in history

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -467,9 +467,9 @@ editSubmitBtn.addEventListener('click', async function () {
 async function openForEdit(row) {
   currentId = row.id;
   editSubmitBtn.dataset.id = row.id;
-  document.getElementById('edit-floor').value = row.floor;
-  await loadRooms(row.floor, '#edit-room');
-  document.getElementById('edit-room').value = row.room;
+  document.getElementById('edit-floor').value = row.floor_id;
+  await loadRooms(row.floor_id, '#edit-room');
+  document.getElementById('edit-room').value = row.room_id;
   document.getElementById('edit-lot').value = row.lot;
   document.getElementById('edit-lot').dispatchEvent(new Event('change'));
   document.querySelector('#edit-table tbody').innerHTML = '';
@@ -550,7 +550,8 @@ window.addEventListener('DOMContentLoaded', async () => {
   const lotOptions = Object.keys(lotTasks)
     .map(l => `<option value="${l}">${l}</option>`)
     .join('');
-  document.getElementById('edit-lot').innerHTML = '<option value="">-- Lot --</option>' + lotOptions;
+  document.getElementById('edit-lot').innerHTML =
+    '<option value="">-- Tous les lots --</option>' + lotOptions;
   document.getElementById('edit-lot').addEventListener('change', () => {
     document.querySelector('#edit-table tbody').innerHTML = '';
     addEditRow();
@@ -569,12 +570,17 @@ window.addEventListener('DOMContentLoaded', async () => {
   // Afficher d'emblée l'Historique
   showTab('historyTab');
   await loadHistory();
-  document.getElementById('edit-floor').addEventListener('change', loadPreview);
+  // Quand l'étage change, on recharge la liste des chambres puis la préview
+  document.getElementById('edit-floor').addEventListener('change', () => {
+    loadRooms(document.getElementById('edit-floor').value, '#edit-room')
+      .then(() => {
+        loadPreview();
+      });
+  });
   document.getElementById('edit-room').addEventListener('change', loadPreview);
   document.getElementById('edit-lot').addEventListener('change', loadPreview);
   document.getElementById('hist-floor').addEventListener('change', e => loadRooms(e.target.value, '#hist-room'));
   document.getElementById('hist-state').addEventListener('change', loadHistory);
-  document.getElementById('edit-floor').addEventListener('change', e => loadRooms(e.target.value, '#edit-room'));
   document.getElementById('hist-refresh').addEventListener('click', loadHistory);
   // ouverture du modal d’export
   document.getElementById('export-config').onclick = () => {

--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -221,13 +221,15 @@ router.get('/history', async (req, res) => {
       i.status        AS state,
       i.created_at    AS date,
       f.name          AS floor,
-      r.name          AS room
+      r.name          AS room,
+      i.floor_id      AS floor_id,
+      i.room_id       AS room_id
     FROM interventions i
     JOIN floors f     ON f.id = i.floor_id
     LEFT JOIN rooms r ON r.id = i.room_id
     LEFT JOIN users u1 ON u1.id::text = i.user_id
     LEFT JOIN users u2 ON u2.id::text = i.person
-    WHERE ($1 = '' OR f.name      = $1)
+    WHERE ($1 = '' OR f.id::text  = $1)
       AND ($2 = '' OR i.room_id::text = $2)
       AND ($3 = '' OR i.lot       = $3)
       AND ($4 = '' OR i.status    = $4)


### PR DESCRIPTION
## Summary
- include `floor_id` and `room_id` fields when listing history
- update edit form to rely on these ids
- always show "Tous les lots" option on lot selector
- refresh preview when changing the selected floor
- filter history by floor id instead of floor name
- remove duplicate change listener for the floor selector

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688889d3b79c8327a793763e73eacde0