### PR TITLE
Fix export columns for floor/room

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -150,16 +150,10 @@ async function loadCommentUsers() {
 
 function setupExportModal() {
   const allCols = [
-    'id',
-    'created_by',
-    'action',
-    'lot',
-    'floor_id',
-    'room_id',
-    'task',
-    'status',
-    'last_modified_by',
-    'created_at'
+    'id', 'created_by', 'action',
+    'lot', 'floor', 'room',
+    'task', 'status',
+    'last_modified_by', 'created_at'
   ];
   const labels = [
     'ID',


### PR DESCRIPTION
## Summary
- adjust default export columns to use floor and room names
- join floors and rooms tables when exporting
- update export modal field list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888c1d76554832794142ad67ac8c618