### PR TITLE
Enable default column selection for export

### DIFF
--- a/public/selection.js
+++ b/public/selection.js
@@ -174,9 +174,24 @@ function setupExportModal() {
     container.id = 'export-cols';
     dlg.insertBefore(container, dlg.querySelector('hr'));
   }
+  // colonnes à cocher par défaut
+  const defaultChecked = new Set([
+    'created_by',
+    'action',
+    'lot',
+    'floor',
+    'room',
+    'task',
+    'status',
+    'last_modified_by'
+  ]);
   container.innerHTML = allCols.map((c,i) => `
     <label>
-      <input type="checkbox" value="${c}">
+      <input
+        type="checkbox"
+        value="${c}"
+        ${defaultChecked.has(c) ? 'checked' : ''}
+      >
       ${labels[i]}
     </label>
   `).join('');


### PR DESCRIPTION
## Summary
- default-check relevant export columns when opening the export modal

## Testing
- `node --check public/selection.js`

------
https://chatgpt.com/codex/tasks/task_e_6888c6e9cd8c8327a334adc1a5b9fe43