### PR TITLE
Add action field to history API

### DIFF
--- a/routes/interventions.js
+++ b/routes/interventions.js
@@ -216,6 +216,7 @@ router.get('/history', async (req, res) => {
       i.id,
       u1.email        AS created_by,
       u2.email        AS last_modified_by,
+      i.action        AS action,
       i.lot,
       i.task,
       i.status        AS state,


### PR DESCRIPTION
## Summary
- include `action` column in `/api/interventions/history` results

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888cacdfa7c832792caa26bdde23eaf