### PR TITLE
Add room creation button and backend endpoint

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -75,6 +75,28 @@ document.addEventListener('DOMContentLoaded', () => {
         await updateFloorOptions(chantierSelect.value);
       };
 
+      // +-------------------------------------------------------------+
+      // | Bouton “+ Nouvelle chambre”                                |
+      // +-------------------------------------------------------------+
+      const roomBtn = document.createElement('button');
+      roomBtn.id = 'addRoomBtn';
+      roomBtn.textContent = '+ Nouvelle chambre';
+      chambreSelect.parentNode.appendChild(roomBtn);
+      roomBtn.onclick = async () => {
+        const nom = prompt('Numéro ou nom de la chambre');
+        if (!nom) return;
+        await fetch('/api/rooms', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            floor_id: parseInt(etageSelect.value, 10),
+            name: nom
+          })
+        });
+        await updateRoomOptions(etageSelect.value);
+      };
+
       const uploadInput = document.createElement('input');
       uploadInput.type = 'file';
       uploadInput.accept = '.pdf,.png';

--- a/routes/rooms.js
+++ b/routes/rooms.js
@@ -20,4 +20,27 @@ router.get('/', async (req, res) => {
   }
 });
 
+// POST /api/rooms — créer une nouvelle chambre
+router.post('/', async (req, res) => {
+  if (!req.session.user || req.session.user.email !== 'launay.jeremy@batirenov.info') {
+    return res.status(403).json({ error: 'Interdit' });
+  }
+  const { floor_id, name } = req.body;
+  if (!floor_id || !name) {
+    return res.status(400).json({ error: 'floor_id et name sont requis' });
+  }
+  try {
+    const result = await pool.query(
+      `INSERT INTO rooms (floor_id, name, created_by, created_at)
+       VALUES ($1, $2, $3, now())
+       RETURNING id, name`,
+      [floor_id, name, req.session.user.id]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Impossible de créer la chambre' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- add an admin button to create new rooms in `public/script.js`
- support POST `/api/rooms` for new room creation

## Testing
- `node --check public/script.js`
- `node --check routes/rooms.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888d0dd28f08327a580df5bd47556d9