### PR TITLE
Add chambre filter and modified by export option

### DIFF
--- a/public/historique.html
+++ b/public/historique.html
@@ -11,6 +11,17 @@
     <h1>Historique des actions</h1>
     <button id="backBtn">Retour</button>
   </header>
+  <form id="history-filters">
+    Chantier :
+    <select id="filter-chantier"><option value="">Tous</option></select>
+    Étage :
+    <select id="filter-etage"><option value="">Tous</option></select>
+    Chambre :
+    <select id="filter-chambre"><option value="">Toutes</option></select>
+    Lot :
+    <input type="text" id="filter-lot" placeholder="Lot" />
+    <button type="submit">Filtrer</button>
+  </form>
   <main id="tableWrapper">
     <table id="historyTable">
       <thead>

--- a/public/historique.js
+++ b/public/historique.js
@@ -1,44 +1,86 @@
 window.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
-  fetch('/api/history', { credentials: 'include' })
-    .then(r => r.json())
-    .then(rows => {
-      if (rows.length === 0) {
-        const row = document.createElement('tr');
-        const cell = document.createElement('td');
-        cell.colSpan = 14;
-        cell.textContent = 'Aucune action enregistrée.';
-        row.appendChild(cell);
-        tbody.appendChild(row);
-      } else {
-        tbody.innerHTML = rows.map(data => `
-          <tr>
-            <td>${data.username}</td>
-            <td>${data.action_type}</td>
-            <td>${data.chantier}</td>
-            <td>${data.intitule || ''}</td>
-            <td>${data.etat || ''}</td>
-            <td>${data.etage}</td>
-            <td>${data.chambre}</td>
-            <td>${data.bulle_numero}</td>
-            <td>${data.lot}</td>
-            <td>${data.entreprise || ''}</td>
-            <td>${data.localisation || ''}</td>
-            <td>${data.observation || ''}</td>
-            <td>${data.description || ''}</td>
-            <td>${new Date(data.created_at).toLocaleString()}</td>
-          </tr>
-        `).join('');
-      }
-    })
-    .catch(err => {
-      console.error(err);
+
+  function renderRows(rows) {
+    if (!rows || rows.length === 0) {
       const row = document.createElement('tr');
       const cell = document.createElement('td');
       cell.colSpan = 14;
-      cell.textContent = 'Erreur chargement historique';
+      cell.textContent = 'Aucune action enregistrée.';
       row.appendChild(cell);
+      tbody.innerHTML = '';
       tbody.appendChild(row);
+      return;
+    }
+    tbody.innerHTML = rows.map(data => `
+      <tr>
+        <td>${data.username}</td>
+        <td>${data.action_type}</td>
+        <td>${data.chantier}</td>
+        <td>${data.intitule || ''}</td>
+        <td>${data.etat || ''}</td>
+        <td>${data.etage}</td>
+        <td>${data.chambre}</td>
+        <td>${data.bulle_numero}</td>
+        <td>${data.lot}</td>
+        <td>${data.entreprise || ''}</td>
+        <td>${data.localisation || ''}</td>
+        <td>${data.observation || ''}</td>
+        <td>${data.description || ''}</td>
+        <td>${new Date(data.created_at).toLocaleString()}</td>
+      </tr>
+    `).join('');
+  }
+
+  async function loadFilters() {
+    const ch = await fetch('/api/chantiers', {credentials:'include'}).then(r=>r.json());
+    document.getElementById('filter-chantier').innerHTML =
+      '<option value="">Tous</option>' +
+      ch.map(c=>`<option value="${c.id}">${c.nom}</option>`).join('');
+
+    document.getElementById('filter-chantier').onchange = async e => {
+      const et = await fetch(`/api/floors?chantier_id=${e.target.value}`,
+        {credentials:'include'}).then(r=>r.json());
+      document.getElementById('filter-etage').innerHTML =
+        '<option value="">Tous</option>' +
+        et.map(f=>`<option value="${f.id}">${f.name}</option>`).join('');
+      document.getElementById('filter-chambre').innerHTML = '<option value="">Toutes</option>';
+    };
+
+    document.getElementById('filter-etage').onchange = async e => {
+      const rooms = await fetch(`/api/rooms?floor_id=${e.target.value}`,
+        {credentials:'include'}).then(r=>r.json());
+      document.getElementById('filter-chambre').innerHTML =
+        '<option value="">Toutes</option>' +
+        rooms.map(r=>`<option value="${r.name}">${r.name}</option>`).join('');
+    };
+  }
+
+  loadFilters();
+
+  document.getElementById('history-filters').onsubmit = e => {
+    e.preventDefault();
+    const qs = new URLSearchParams({
+      chantier_id: document.getElementById('filter-chantier').value || '',
+      etage_id:    document.getElementById('filter-etage').value || '',
+      chambre:     document.getElementById('filter-chambre').value || '',
+      lot:         document.getElementById('filter-lot').value || ''
+    });
+    fetch('/api/history?' + qs.toString(), {credentials:'include'})
+      .then(r=>r.json())
+      .then(renderRows)
+      .catch(err => {
+        console.error(err);
+        renderRows([]);
+      });
+  };
+
+  fetch('/api/history', { credentials: 'include' })
+    .then(r => r.json())
+    .then(renderRows)
+    .catch(err => {
+      console.error(err);
+      renderRows([]);
     });
 
   document.getElementById('backBtn').addEventListener('click', () => {

--- a/public/index.html
+++ b/public/index.html
@@ -62,6 +62,7 @@
       <legend>Colonnes à inclure :</legend>
       <label><input type="checkbox" name="col" value="id" checked> ID</label>
       <label><input type="checkbox" name="col" value="created_by_email" checked> Utilisateur</label>
+      <label><input type="checkbox" name="col" value="modified_by"> Modifié par</label>
       <label><input type="checkbox" name="col" value="etage" checked> Étage</label>
       <label><input type="checkbox" name="col" value="chambre" checked> Chambre</label>
       <label><input type="checkbox" name="col" value="numero" checked> N°</label>

--- a/public/script.js
+++ b/public/script.js
@@ -708,7 +708,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const params = new URLSearchParams();
       params.set('chantier_id', chantierSelect.value);
       params.set('etage_id',    etageSelect.value);
-      params.set('room_id',     chambreSelect.value);
+      params.set('chambre',      chambreSelect.value);
       params.set('format',      formatSelect.value);
 
       document.querySelectorAll('#export-columns input[name="col"]:checked')

--- a/routes/export.js
+++ b/routes/export.js
@@ -35,7 +35,7 @@ router.get('/', async (req, res) => {
       b.*, f.name AS etage,
       e.nom AS entreprise,
       u1.email AS created_by_email,
-      u2.email AS modified_by_email
+      u2.email AS modified_by
     FROM bulles b
     LEFT JOIN floors f ON b.etage_id = f.id
     LEFT JOIN entreprises e ON b.entreprise_id = e.id
@@ -48,8 +48,8 @@ router.get('/', async (req, res) => {
 
   // On extrait dynamiquement les noms de colonnes
   let cols = rows.length > 0 ? Object.keys(rows[0]) : [];
-  // On retire les champs numériques qui ne nous intéressent plus
-  cols = cols.filter(c => c !== 'created_by' && c !== 'modified_by');
+  // On retire les identifiants numériques inutiles
+  cols = cols.filter(c => c !== 'created_by');
 
   // --- BEGIN : Réordonnage fixe des colonnes ---
   // On veut d'abord ces colonnes dans cet ordre :
@@ -64,7 +64,7 @@ router.get('/', async (req, res) => {
     'entreprise',
     'localisation',
     'created_by_email',
-    'modified_by_email'
+    'modified_by'
   ];
   // On filtre pour ne garder que celles qui existent encore dans cols
   const head = desiredOrder.filter(c => cols.includes(c));

--- a/routes/history.js
+++ b/routes/history.js
@@ -14,6 +14,10 @@ router.get('/', async (req, res) => {
     where += ` AND b.etage_id = $${idx++}`;
     params.push(etage_id);
   }
+  if (req.query.chambre && req.query.chambre !== 'total') {
+    where += ` AND b.chambre = $${idx++}`;
+    params.push(req.query.chambre);
+  }
   if (lot) {
     where += ` AND b.lot = $${idx++}`;
     params.push(lot);


### PR DESCRIPTION
## Summary
- include a "Modifié par" column in export options
- fix export parameter name for room selector
- allow filtering history by chambre in the backend
- add filter form to history page and fetch cascade lists
- support filtering history table with frontend script
- make export route expose `modified_by` alias

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889f4c8265083279806cdbde8199295