### PR TITLE
Fix duplicate uploads and extend export UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -74,6 +74,8 @@
       <label><input type="checkbox" name="col" value="localisation" checked> Localisation</label>
       <label><input type="checkbox" name="col" value="observation" checked> Observation</label>
       <label><input type="checkbox" name="col" value="date_butoir" checked> Date butoir</label>
+      <label><input type="checkbox" name="col" value="photos"> Photos (tous les liens)</label>
+      <label><input type="checkbox" name="col" value="videos"> Vidéos (tous les liens)</label>
     </fieldset>
     <!-- Nouveau bouton Export -->
     <button id="exportBtn">Exporter</button>

--- a/routes/bulles.js
+++ b/routes/bulles.js
@@ -25,7 +25,10 @@ router.post("/", /* isAuthenticated, */ upload.array('media', 15), async (req, r
     const safeDate = date_butoir === "" ? null : date_butoir;
     const files = req.files || [];
     console.log(req.files);
-    const firstPhoto = files.find(f => f.mimetype.startsWith('image/'));
+    const uniqueFiles = Array.from(
+      new Map(files.map(f => [f.path, f])).values()
+    );
+    const firstPhoto = uniqueFiles.find(f => f.mimetype.startsWith('image/'));
     const photo = firstPhoto ? firstPhoto.path : null;
 
     const insertRes = await pool.query(
@@ -36,7 +39,7 @@ router.post("/", /* isAuthenticated, */ upload.array('media', 15), async (req, r
     );
 
     const newBulle = insertRes.rows[0];
-    for (const file of files) {
+    for (const file of uniqueFiles) {
       await pool.query(
         'INSERT INTO bulle_media(bulle_id,type,path) VALUES($1,$2,$3)',
         [
@@ -111,7 +114,10 @@ router.put("/:id", /* isAuthenticated, */ upload.array('media', 15), async (req,
     const safeDate = date_butoir === "" ? null : date_butoir;
     const files = req.files || [];
     console.log(req.files);
-    const firstPhoto = files.find(f => f.mimetype.startsWith('image/'));
+    const uniqueFiles = Array.from(
+      new Map(files.map(f => [f.path, f])).values()
+    );
+    const firstPhoto = uniqueFiles.find(f => f.mimetype.startsWith('image/'));
     const photo = firstPhoto ? firstPhoto.path : null;
 
     // Récupérer l'état actuel complet pour l'historique
@@ -143,7 +149,7 @@ router.put("/:id", /* isAuthenticated, */ upload.array('media', 15), async (req,
       'SELECT path FROM bulle_media WHERE bulle_id = $1', [id]
     );
     const existingPaths = new Set(existing.map(r => r.path));
-    for (const file of files) {
+    for (const file of uniqueFiles) {
       if (!existingPaths.has(file.path)) {
         const type = file.mimetype.startsWith('video/') ? 'video' : 'photo';
         await pool.query(


### PR DESCRIPTION
## Summary
- prevent duplicate media entries when creating or editing a *bulle*
- add export checkboxes for photo and video URLs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b432fcb808327b701b0fcab883e24