### PR TITLE
Deduplicate front media and improve video preview

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -205,6 +205,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function createBulle(bulle) {
+      // Deduplicate media entries by path to avoid duplicates in UI
+      bulle.media = Array.from(
+        new Map((bulle.media || []).map(m => [m.path, m])).values()
+      );
       const div = document.createElement('div');
       div.className = 'bulle';
       const rect = plan.getBoundingClientRect();

--- a/public/styles.css
+++ b/public/styles.css
@@ -175,6 +175,9 @@ button:hover {
 
 .popup .preview-video {
   display: block;
+  max-width: 100%;
+  margin-top: 8px;
+  border-radius: 5px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate media items on popup creation
- style popup video previews

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b7084e7a083279288068dbce80dcf