### PR TITLE
Ensure photos/videos positioned before etat

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -74,8 +74,8 @@
       <label><input type="checkbox" name="col" value="localisation" checked> Localisation</label>
       <label><input type="checkbox" name="col" value="observation" checked> Observation</label>
       <label><input type="checkbox" name="col" value="date_butoir" checked> Date butoir</label>
-      <label><input type="checkbox" name="col" value="photos"> Photos (tous les liens)</label>
-      <label><input type="checkbox" name="col" value="videos"> Vidéos (tous les liens)</label>
+      <label><input type="checkbox" name="col" value="photos" checked> Photos (tous les liens)</label>
+      <label><input type="checkbox" name="col" value="videos" checked> Vidéos (tous les liens)</label>
     </fieldset>
     <!-- Nouveau bouton Export -->
     <button id="exportBtn">Exporter</button>

--- a/routes/export.js
+++ b/routes/export.js
@@ -110,6 +110,18 @@ router.get('/', async (req, res) => {
       ? req.query.columns
       : [req.query.columns];
     cols = sel.filter(c => cols.includes(c));
+
+    // repositionner photos & videos juste avant 'etat'
+    if (cols.includes('photos') && cols.includes('etat')) {
+      cols = cols.filter(c => c !== 'photos');
+      const idx = cols.indexOf('etat');
+      cols.splice(idx, 0, 'photos');
+    }
+    if (cols.includes('videos') && cols.includes('etat')) {
+      cols = cols.filter(c => c !== 'videos');
+      const idx = cols.indexOf('etat');
+      cols.splice(idx, 0, 'videos');
+    }
   }
 
   const format = (req.query.format || 'csv').toLowerCase();


### PR DESCRIPTION
## Summary
- keep dynamic export columns `photos` and `videos` right before `etat`
- have Photos and Videos fields checked by default in the UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b78b7a6148327ab297ad95f0403de