### PR TITLE
feat: render sidebar only when authenticated

### DIFF
--- a/public/sidebar.css
+++ b/public/sidebar.css
@@ -2,8 +2,21 @@
   position: fixed; left:0; top:0; bottom:0;
   width: 220px; padding:16px;
   background:#0f172a; color:#fff;
+  z-index: 1000;
+  overflow: auto;
 }
 .sidebar a { color:#fff; text-decoration:none; display:block; margin:6px 0; }
 .sidebar .brand { font-weight:700; margin-bottom:12px; }
 .sidebar .user { margin-bottom:12px; }
+/* marge par défaut (écrans larges) */
 body.with-sidebar { margin-left:220px; }
+
+/* écrans moyens : marge un peu réduite */
+@media (max-width: 1280px) {
+  body.with-sidebar { margin-left:200px; }
+}
+
+/* écrans < 992px : pas de marge, contenu en pleine largeur */
+@media (max-width: 992px) {
+  body.with-sidebar { margin-left:0; }
+}

--- a/public/sidebar.js
+++ b/public/sidebar.js
@@ -2,22 +2,28 @@
   const holder = document.getElementById('sidebar-holder');
   if(!holder) return;
 
-  // Charger la sidebar
+  // 1) Vérifier la session AVANT d'injecter la sidebar
+  let user = null;
+  try {
+    const me = await fetch('/api/auth/me', { credentials:'include' });
+    if (!me.ok) return; // non connecté -> on n'affiche rien
+    user = await me.json();
+  } catch (_) {
+    return; // en cas d'erreur réseau, ne rien afficher
+  }
+
+  // 2) Charger la sidebar uniquement si connecté
   const res = await fetch('/sidebar.html', { credentials:'include' });
   holder.innerHTML = await res.text();
   document.body.classList.add('with-sidebar');
 
-  // Afficher l'utilisateur connecté
-  try {
-    const me = await fetch('/api/auth/me', { credentials:'include' });
-    if(me.ok){
-      const data = await me.json();
-      const span = document.getElementById('sidebar-user');
-      if (span && data.user) span.textContent = data.user.email;
-    }
-  } catch(_) {}
+  // 3) Afficher l'email utilisateur si disponible
+  const span = document.getElementById('sidebar-user');
+  if (span && user && user.user && user.user.email) {
+    span.textContent = user.user.email;
+  }
 
-  // Déconnexion
+  // 4) Déconnexion
   const btn = document.getElementById('sidebar-logout');
   if(btn){
     btn.addEventListener('click', async ()=>{


### PR DESCRIPTION
## Summary
- inject sidebar only after confirming active session
- add responsive margins so content isn't compressed

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ad801cea408328bff3a0cd5b59ac2f