### PR TITLE
feat: add sliding sidebar hamburger menu

### DIFF
--- a/public/sidebar.css
+++ b/public/sidebar.css
@@ -1,22 +1,62 @@
+/* Menu hors de l’écran par défaut ; il coulisse lorsqu’il a la classe .open */
 .sidebar {
-  position: fixed; left:0; top:0; bottom:0;
-  width: 220px; padding:16px;
-  background:#0f172a; color:#fff;
-  z-index: 1000;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 220px;
+  padding: 16px;
+  background: #0f172a;
+  color: #fff;
   overflow: auto;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1001;
+}
+.sidebar.open {
+  transform: translateX(0);
 }
 .sidebar a { color:#fff; text-decoration:none; display:block; margin:6px 0; }
 .sidebar .brand { font-weight:700; margin-bottom:12px; }
 .sidebar .user { margin-bottom:12px; }
-/* marge par défaut (écrans larges) */
-body.with-sidebar { margin-left:220px; }
 
-/* écrans moyens : marge un peu réduite */
-@media (max-width: 1280px) {
-  body.with-sidebar { margin-left:200px; }
+/* On ne décale plus le contenu global : le menu se superpose */
+body.with-sidebar { margin-left: 0; }
+
+/* Ajout d’un overlay qui assombrit l’écran quand la sidebar est ouverte */
+.sidebar-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  pointer-events: none;      /* Micro-patch #1 : pas de clics quand caché */
+  z-index: 1000;
+}
+.sidebar-overlay.show {
+  display: block;
+  pointer-events: auto;      /* clics actifs seulement quand visible */
 }
 
-/* écrans < 992px : pas de marge, contenu en pleine largeur */
-@media (max-width: 992px) {
-  body.with-sidebar { margin-left:0; }
+/* Bouton burger pour ouvrir/fermer la sidebar */
+#sidebar-toggle {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: #0f172a;
+  color: #fff;
+  font-size: 24px;
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 1002;
+}
+
+/* Micro-patch #3 : empêcher le scroll de fond quand le menu est ouvert */
+body.menu-open {
+  overflow: hidden;
 }

--- a/public/sidebar.js
+++ b/public/sidebar.js
@@ -2,28 +2,26 @@
   const holder = document.getElementById('sidebar-holder');
   if(!holder) return;
 
-  // 1) Vérifier la session AVANT d'injecter la sidebar
+  // Vérifier la session AVANT d'injecter la sidebar
   let user = null;
   try {
     const me = await fetch('/api/auth/me', { credentials:'include' });
-    if (!me.ok) return; // non connecté -> on n'affiche rien
+    if (!me.ok) return; // non connecté -> ne rien afficher
     user = await me.json();
   } catch (_) {
-    return; // en cas d'erreur réseau, ne rien afficher
+    return;
   }
 
-  // 2) Charger la sidebar uniquement si connecté
+  // Charger la sidebar
   const res = await fetch('/sidebar.html', { credentials:'include' });
   holder.innerHTML = await res.text();
   document.body.classList.add('with-sidebar');
 
-  // 3) Afficher l'email utilisateur si disponible
   const span = document.getElementById('sidebar-user');
-  if (span && user && user.user && user.user.email) {
+  if(span && user && user.user && user.user.email){
     span.textContent = user.user.email;
   }
 
-  // 4) Déconnexion
   const btn = document.getElementById('sidebar-logout');
   if(btn){
     btn.addEventListener('click', async ()=>{
@@ -31,4 +29,51 @@
       location.href = '/';
     });
   }
+
+  // Créer overlay et bouton burger pour ouvrir/fermer la sidebar
+  const sidebar = holder.querySelector('.sidebar');
+  const overlay = document.createElement('div');
+  overlay.className = 'sidebar-overlay';
+  document.body.appendChild(overlay);
+  // Micro-patch #4 : éviter les doublons de bouton si le script est ré-exécuté
+  let toggle = document.getElementById('sidebar-toggle');
+  if (!toggle) {
+    toggle = document.createElement('button');
+    toggle.id = 'sidebar-toggle';
+    document.body.appendChild(toggle);
+  }
+  toggle.textContent = '☰';
+  // Micro-patch #2 : accessibilité
+  toggle.setAttribute('aria-label', 'Ouvrir le menu');
+  toggle.setAttribute('aria-expanded', 'false');
+
+  function openSidebar() {
+    sidebar.classList.add('open');
+    overlay.classList.add('show');
+    document.body.classList.add('menu-open');     // Micro-patch #3
+    toggle.setAttribute('aria-expanded', 'true'); // Micro-patch #2
+  }
+  function closeSidebar() {
+    sidebar.classList.remove('open');
+    overlay.classList.remove('show');
+    document.body.classList.remove('menu-open');  // Micro-patch #3
+    toggle.setAttribute('aria-expanded', 'false');// Micro-patch #2
+  }
+
+  toggle.addEventListener('click', () => {
+    if (sidebar.classList.contains('open')) {
+      closeSidebar();
+    } else {
+      openSidebar();
+    }
+  });
+  overlay.addEventListener('click', closeSidebar);
+
+  // Micro-patch #2 : fermer avec la touche Échap et rendre le focus
+  document.addEventListener('keydown', (e)=>{
+    if (e.key === 'Escape' && sidebar.classList.contains('open')) {
+      closeSidebar();
+      if (typeof toggle.focus === 'function') toggle.focus();
+    }
+  });
 })();


### PR DESCRIPTION
## Summary
- transform fixed sidebar into sliding menu with overlay
- add burger toggle and overlay handling in sidebar script
- harden overlay and menu interactions (escape-to-close, scroll lock, pointer-events, no duplicate button)

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ad84fbdd088328a8329c8873b88f41