### PR TITLE
feat: add light/dark theme with persistence

### DIFF
--- a/public/detail.html
+++ b/public/detail.html
@@ -10,6 +10,7 @@
   <div id="sidebar-holder"></div>
   <link rel="stylesheet" href="/sidebar.css">
   <script src="/sidebar.js" defer></script>
+  <script src="/theme.js" defer></script>
   <header>
     <h1>Détail de la bulle</h1>
     <nav><a href="dashboard.html">Dashboard</a></nav>

--- a/public/historique.html
+++ b/public/historique.html
@@ -10,6 +10,7 @@
   <div id="sidebar-holder"></div>
   <link rel="stylesheet" href="/sidebar.css">
   <script src="/sidebar.js" defer></script>
+  <script src="/theme.js" defer></script>
   <header>
     <h1>Historique des actions</h1>
     <button id="backBtn">Retour</button>

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
   <div id="sidebar-holder"></div>
   <link rel="stylesheet" href="/sidebar.css">
   <script src="/sidebar.js" defer></script>
+  <script src="/theme.js" defer></script>
   <div id="login-container">
     <h2>Connexion</h2>
     <form id="login-form">

--- a/public/selection.html
+++ b/public/selection.html
@@ -11,6 +11,7 @@
   <div id="sidebar-holder"></div>
   <link rel="stylesheet" href="/sidebar.css">
   <script src="/sidebar.js" defer></script>
+  <script src="/theme.js" defer></script>
   <button id="backBtn" class="btn">← Retour</button>
   <nav class="tabs">
     <button data-tab="historyTab">Historique</button>

--- a/public/sidebar.css
+++ b/public/sidebar.css
@@ -6,8 +6,8 @@
   left: 0;
   width: 220px;
   padding: 16px;
-  background: #0f172a;
-  color: #fff;
+  background: var(--panel);
+  color: var(--text);
   overflow: auto;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
@@ -16,7 +16,7 @@
 .sidebar.open {
   transform: translateX(0);
 }
-.sidebar a { color:#fff; text-decoration:none; display:block; margin:6px 0; }
+.sidebar a { color: var(--link); text-decoration:none; display:block; margin:6px 0; }
 .sidebar .brand { font-weight:700; margin-bottom:12px; }
 .sidebar .user { margin-bottom:12px; }
 

--- a/public/sidebar.html
+++ b/public/sidebar.html
@@ -4,6 +4,9 @@
     <span id="sidebar-user">—</span>
     <button id="sidebar-logout">Déconnexion</button>
   </div>
+  <div class="theme-switch">
+    <button id="theme-toggle" onclick="toggleTheme()" aria-pressed="false" title="Thème clair/sombre">☀️ / 🌙</button>
+  </div>
   <ul>
     <li><a href="/index.html">Bulles</a></li>
     <li><a href="/selection.html">Interventions</a></li>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,9 +1,41 @@
+/* === Thème clair/sombre : variables minimales non-intrusives === */
+:root{
+  --bg:#ffffff;
+  --text:#0f172a;        /* ardoise */
+  --panel:#f8fafc;       /* ardoise très clair */
+  --muted:#6b7280;       /* gris pour textes secondaires */
+  --link:#0ea5e9;        /* bleu clair */
+}
+.dark-theme{
+  --bg:#0b1220;
+  --text:#e5e7eb;        /* gris très clair */
+  --panel:#111827;       /* gris/ardoise foncé */
+  --muted:#94a3b8;
+  --link:#38bdf8;
+}
+
+/* Application douce sur la page entière, sans casser les styles existants */
+html, body{
+  background: var(--bg);
+  color: var(--text);
+}
+a{ color: var(--link); }
+small, .muted, .text-muted{ color: var(--muted); }
+
+/* (Optionnel) teinte douce pour les conteneurs courants */
+.panel, .card, .box {
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 12px;
+}
+
 body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f4f6f9;
+  background-color: var(--bg);
   margin: 0;
   padding: 20px;
-  color: #333;
+  color: var(--text);
 }
 
 header {

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,0 +1,36 @@
+/* Thème clair/sombre persistant */
+(function(){
+  const KEY='rb_theme';
+  const root=document.documentElement;
+
+  function apply(theme){
+    if(theme==='dark'){ root.classList.add('dark-theme'); }
+    else{ root.classList.remove('dark-theme'); }
+  }
+
+  // Choix initial : localStorage > prefers-color-scheme > light
+  let initial = localStorage.getItem(KEY);
+  if(!initial){
+    try{
+      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      initial = prefersDark ? 'dark' : 'light';
+    }catch(_){ initial='light'; }
+  }
+  apply(initial);
+
+  // Expose bascule globale pour la sidebar
+  window.toggleTheme = function(){
+    const now = root.classList.contains('dark-theme') ? 'light' : 'dark';
+    localStorage.setItem(KEY, now);
+    apply(now);
+    // Mettre à jour l'état ARIA du bouton si présent
+    const btn = document.getElementById('theme-toggle');
+    if(btn){ btn.setAttribute('aria-pressed', now==='dark' ? 'true' : 'false'); }
+  };
+
+  // (Optionnel) synchroniser l'état ARIA dès le chargement
+  const initBtn = document.getElementById('theme-toggle');
+  if (initBtn) {
+    initBtn.setAttribute('aria-pressed', initial==='dark' ? 'true' : 'false');
+  }
+})();


### PR DESCRIPTION
## Summary
- support light and dark themes via CSS variables
- persist user theme choice in new `theme.js`
- add sidebar toggle to switch theme
- sync initial aria state and style sidebar/panels with theme variables

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68adb7fbc8288328a7eb0c2390bd6a45