### PR TITLE
fix: add PDF export with images and columns

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,9 @@
   <link rel="stylesheet" href="/sidebar.css">
   <script src="/sidebar.js" defer></script>
   <script src="/theme.js" defer></script>
+  <!-- Librairies pour l’export PDF -->
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.4/dist/jspdf.plugin.autotable.min.js"></script>
   <div id="login-container">
     <h2>Connexion</h2>
     <form id="login-form">


### PR DESCRIPTION
## Summary
- include jsPDF and autoTable libraries in index page
- generate PDF export with selected columns and embedded photo thumbnails
- handle CORS for images, add contextual heading, and limit photos per bubble

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b54fd174008328baf90013123fd656