### PR TITLE
feat: enhance PDF export with thumbnails

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -71,56 +71,25 @@ document.addEventListener('DOMContentLoaded', () => {
       ).map(i => i.value);
     }
 
-    // Convertir une image Cloudinary en DataURL (pour PDF)
+    // Image -> DataURL (CORS safe)
     function imageUrlToDataURL(url, maxWidth = 180) {
       return new Promise((resolve) => {
         const img = new Image();
         img.referrerPolicy = 'no-referrer';
         img.crossOrigin = 'anonymous';
         img.onload = () => {
-          const scale = Math.min(1, maxWidth / img.naturalWidth);
-          const w = Math.round(img.naturalWidth * scale);
-          const h = Math.round(img.naturalHeight * scale);
+          const scale = Math.min(1, maxWidth / (img.naturalWidth || 1));
+          const w = Math.max(1, Math.round((img.naturalWidth || maxWidth) * scale));
+          const h = Math.max(1, Math.round((img.naturalHeight || maxWidth) * scale));
           const canvas = document.createElement('canvas');
-          canvas.width = w;
-          canvas.height = h;
+          canvas.width = w; canvas.height = h;
           const ctx = canvas.getContext('2d');
           ctx.drawImage(img, 0, 0, w, h);
-          resolve(canvas.toDataURL('image/jpeg', 0.7));
+          resolve(canvas.toDataURL('image/jpeg', 0.7)); // qualité 70%
         };
         img.onerror = () => resolve(null);
         img.src = url;
       });
-    }
-
-    // Dessiner une grille de photos dans le PDF
-    function drawPhotoGrid(doc, dataUrls, startY = 20) {
-      const pageW   = doc.internal.pageSize.getWidth();
-      const margin  = 14;
-      const colW    = 60;
-      const rowH    = 60;
-      const gap     = 8;
-      const perRow  = Math.max(1, Math.floor((pageW - margin * 2 + gap) / (colW + gap)));
-      let x = margin, y = startY, col = 0;
-      dataUrls.forEach((d) => {
-        if (!d) return;
-        if (y + rowH > doc.internal.pageSize.getHeight() - margin) {
-          doc.addPage();
-          x = margin;
-          y = margin;
-          col = 0;
-        }
-        try { doc.addImage(d, 'JPEG', x, y, colW, rowH); } catch(_) {}
-        col++;
-        if (col >= perRow) {
-          col = 0;
-          x = margin;
-          y += rowH + gap;
-        } else {
-          x += colW + gap;
-        }
-      });
-      return y + rowH;
     }
 
     // Boutons d'ajout visibles pour Jeremy Launay et Valentin Blot
@@ -823,88 +792,141 @@ document.addEventListener('DOMContentLoaded', () => {
       updateRoomOptions(id);
       loadBulles();
     };
-    chambreSelect.onchange = loadBulles;
-    exportBtn.onclick = async () => {
-      const fmt = (formatSelect.value || 'csv').toLowerCase();
-      if (fmt !== 'pdf') {
-        const params = new URLSearchParams();
-        params.set('chantier_id', chantierSelect.value);
-        params.set('etage_id',    etageSelect.value);
-        params.set('chambre',      chambreSelect.value);
-        params.set('format',      fmt);
-
-        document.querySelectorAll('#export-columns input[name="col"]:checked')
-          .forEach(cb => params.append('columns', cb.value));
-
-        window.open(`/api/bulles/export?${params.toString()}`, '_blank');
-        return;
-      }
-
-      // --- Récupérer les données et colonnes sélectionnées ---
-      const chantierId = chantierSelect.value;
-      const etageId    = etageSelect.value;
-      let url = `/api/bulles?chantier_id=${chantierId}&etage_id=${etageId}`;
-      if (chambreSelect.value !== 'total') {
-        url += `&chambre=${chambreSelect.value}`;
-      }
-      const data = await fetch(url, { credentials: 'include' }).then(r => r.json());
-      const cols = getCheckedColumns();
-
-      // --- Générer le PDF ---
-      const { jsPDF } = window.jspdf || {};
-      const doc = new jsPDF({ unit: 'pt', format: 'a4' });
-      doc.setFontSize(12);
-      doc.text(
-        `Export bulles — Chantier: ${chantierSelect.options[chantierSelect.selectedIndex]?.text || chantierSelect.value} — ` +
-        `Étage: ${etageSelect.value} — Chambre: ${chambreSelect.value}`,
-        14, 16
-      );
-
-      // Table récapitulant les colonnes sélectionnées
-      const head = [cols.map(c => c.toUpperCase())];
-      const rows = data.map(row => cols.map(c => {
-        if (c === 'photos' || c === 'videos') {
-          const arr = Array.isArray(row.media)
-            ? row.media.filter(m => (c === 'photos' ? m.type === 'photo' : m.type !== 'photo'))
-            : [];
-          return arr.map(m => m.path).join('\n');
+      chambreSelect.onchange = loadBulles;
+      exportBtn.onclick = async () => {
+        const fmt = (formatSelect.value || 'csv').toLowerCase();
+        if (fmt !== 'pdf') {
+          const params = new URLSearchParams();
+          params.set('chantier_id', chantierSelect.value);
+          params.set('etage_id',    etageSelect.value);
+          params.set('chambre',      chambreSelect.value);
+          params.set('format',      fmt);
+          document.querySelectorAll('#export-columns input[name="col"]:checked')
+            .forEach(cb => params.append('columns', cb.value));
+          window.open(`/api/bulles/export?${params.toString()}`, '_blank');
+          return;
         }
-        return (row[c] ?? '').toString();
-      }));
-      if (doc.autoTable) {
-        doc.autoTable({
-          head,
-          body: rows,
-          styles: { fontSize: 8, cellPadding: 3 },
-          headStyles: { fillColor: [15, 23, 42], textColor: 255 },
-          startY: 32,
-          margin: { left: 14, right: 14 }
+
+        // --- PDF ---
+        let url = `/api/bulles?chantier_id=${chantierSelect.value}&etage_id=${etageSelect.value}`;
+        if (chambreSelect.value !== 'total') url += `&chambre=${chambreSelect.value}`;
+        const data = await fetch(url, { credentials:'include' }).then(r => r.json());
+        const cols = getCheckedColumns(); // inclut 'photos' et 'videos' si cochés
+
+        if (!window.jspdf || !window.jspdf.jsPDF) {
+          alert('Export PDF indisponible (librairies non chargées)');
+          return;
+        }
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF({ unit:'pt', format:'a4' });
+        const margin = 24;
+
+        // libellés et largeurs fixes
+        const labels = {
+          id:'ID', created_by_email:'Créé par', etage:'Étage', chambre:'Chambre',
+          numero:'N°', lot:'Lot', intitule:'Intitulé', description:'Description',
+          etat:'État', entreprise:'Entreprise', localisation:'Localisation',
+          observation:'Observation', date_butoir:'Date butoir',
+          photos:'Photos', videos:'Vidéos'
+        };
+        const colW = {
+          id:30, created_by_email:120, etage:40, chambre:56, numero:30, lot:46,
+          intitule:120, description:160, etat:54, entreprise:90, localisation:110,
+          observation:140, date_butoir:80, photos:150, videos:60
+        };
+        const columnStyles = {};
+        cols.forEach((c, i) => {
+          columnStyles[i] = { cellWidth: colW[c] || 90, overflow:'linebreak', valign:'top' };
         });
-      }
 
-      // Section photos : pour chaque bulle
-      let y = doc.lastAutoTable ? doc.lastAutoTable.finalY + 16 : 40;
-      const margin = 14;
-      for (let i = 0; i < data.length; i++) {
-        const b = data[i];
-        const photos = Array.isArray(b.media) ? b.media.filter(m => m.type === 'photo') : [];
-        if (!photos.length) continue;
-        if (y + 24 > doc.internal.pageSize.getHeight() - margin) {
-          doc.addPage();
-          y = margin;
+        // troncature douce
+        const MAX_CELL = 120;
+        const softText = v => {
+          const s = (v ?? '').toString().replace(/\s+/g,' ').trim();
+          return s.length > MAX_CELL ? s.slice(0, MAX_CELL) + '…' : s;
+        };
+
+        // vignettes photos (max 3) & nombre de vidéos
+        const THUMB_W = 42, THUMB_H = 28, THUMB_GAP = 4, MAX_THUMBS = 3;
+        const photoThumbsPerRow = await Promise.all(data.map(async b => {
+          const photos = Array.isArray(b.media) ? b.media.filter(m=>m.type==='photo') : [];
+          const subset = photos.slice(0, MAX_THUMBS);
+          const urls  = await Promise.all(subset.map(p => imageUrlToDataURL(p.path, 220)));
+          return urls.filter(Boolean);
+        }));
+        const videosCount = data.map(b =>
+          Array.isArray(b.media) ? b.media.filter(m => m.type !== 'photo').length : 0
+        );
+
+        // table : pas d’URL brute, PHOTOS remplies via didDrawCell
+        const head = [cols.map(c => labels[c] || c.toUpperCase())];
+        const body = data.map((b, idx) => cols.map(c => {
+          if (c === 'photos') {
+            const n = photoThumbsPerRow[idx]?.length || 0;
+            return n ? ' ' : '—';
+          }
+          if (c === 'videos') {
+            const n = videosCount[idx] || 0;
+            return n ? `🎬 x${n}` : '—';
+          }
+          return softText(b[c]);
+        }));
+
+        // en-tête
+        doc.setFontSize(12);
+        const chantierNom = chantierSelect.options[chantierSelect.selectedIndex]?.text || chantierSelect.value;
+        doc.text(
+          `Export bulles — Chantier: ${chantierNom} — Étage: ${etageSelect.value} — Chambre: ${chambreSelect.value}`,
+          margin, margin
+        );
+
+        // table
+        doc.autoTable({
+          head, body,
+          startY: margin + 14,
+          margin: { left: margin, right: margin },
+          styles: { fontSize: 9, cellPadding: 4, lineColor: [230,230,230], lineWidth: 0.2 },
+          headStyles: { fillColor: [15,23,42], textColor: 255, halign:'center' },
+          columnStyles,
+          didParseCell: (hook) => {
+            hook.cell.styles.wordBreak = 'break-word';
+            const colName = cols[hook.column.index];
+            if (hook.section === 'body' && colName === 'photos') {
+              hook.cell.height = Math.max(hook.cell.height, THUMB_H + 8); // place pour vignettes
+            }
+          },
+          didDrawCell: (hook) => {
+            if (hook.section !== 'body') return;
+            const colName = cols[hook.column.index];
+            if (colName !== 'photos') return;
+            const rowIndex = hook.row.index;
+            const thumbs = photoThumbsPerRow[rowIndex] || [];
+            if (!thumbs.length) return;
+
+            const { x, y, height } = hook.cell;
+            let cx = x + 4;
+            const cy = y + (height - THUMB_H) / 2;
+            thumbs.slice(0, MAX_THUMBS).forEach(d => {
+              try { doc.addImage(d, 'JPEG', cx, cy, THUMB_W, THUMB_H); } catch(_) {}
+              cx += THUMB_W + THUMB_GAP;
+            });
+            hook.cell.text = []; // pas de texte dans la cellule photo
+          }
+        });
+
+        // pied de page
+        const pageCount = doc.getNumberOfPages();
+        for (let i=1; i<=pageCount; i++) {
+          doc.setPage(i);
+          doc.setFontSize(8);
+          doc.text(`${i} / ${pageCount}`, doc.internal.pageSize.getWidth() - margin, doc.internal.pageSize.getHeight() - 10, { align:'right' });
         }
-        doc.setFontSize(11);
-        doc.text(`Bulle ${b.numero || ''} — ${b.intitule || ''}`, margin, y);
-        y += 10;
-        const MAX_PHOTOS = 24; // limite pour éviter un PDF trop lourd
-        const subset = photos.slice(0, MAX_PHOTOS);
-        const urls = await Promise.all(subset.map(p => imageUrlToDataURL(p.path, 180)));
-        y = drawPhotoGrid(doc, urls, y + 4);
-      }
-      // Enregistrer
-      const filename = 'export_bulles_' + new Date().toISOString().slice(0, 10) + '.pdf';
-      doc.save(filename);
-    };
+
+        // IMPORTANT : Supprimer toute ancienne "galerie de photos en bas" (drawPhotoGrid etc.)
+        // => retire le code qui dessinait des images après la table PDF.
+
+        doc.save('export_bulles_' + new Date().toISOString().slice(0,10) + '.pdf');
+      };
 
     window.addEventListener('resize', ajusterTailleBulles);
     window.addEventListener('orientationchange', ajusterTailleBulles);


### PR DESCRIPTION
## Summary
- add robust helpers for column selection and image conversion
- refactor PDF export to render photo thumbnails and video counts in table
- drop legacy photo gallery from PDF output

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b55ad72f78832882d99485ffeae9fa