### PR TITLE
feat: include modifier email in exports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,7 +80,7 @@
       <legend>Colonnes à inclure :</legend>
       <label><input type="checkbox" name="col" value="id" checked> ID</label>
       <label><input type="checkbox" name="col" value="created_by_email" checked> Utilisateur</label>
-      <label><input type="checkbox" name="col" value="modified_by"> Modifié par</label>
+      <label><input type="checkbox" name="col" value="modified_by_email"> Modifié par (email)</label>
       <label><input type="checkbox" name="col" value="etage" checked> Étage</label>
       <label><input type="checkbox" name="col" value="chambre" checked> Chambre</label>
       <label><input type="checkbox" name="col" value="numero" checked> N°</label>

--- a/public/script.js
+++ b/public/script.js
@@ -857,7 +857,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const selected = getCheckedColumns();
 
         // Ordre lisible + "photos" toujours en dernier si cochée
-        const ORDER = ['created_by_email','etage','chambre','numero','lot','intitule','description','etat','entreprise','localisation','observation','date_butoir','photos'];
+        const ORDER = ['created_by_email','modified_by_email','etage','chambre','numero','lot','intitule','description','etat','entreprise','localisation','observation','date_butoir','photos'];
         let cols = ORDER.filter(c => selected.includes(c));
         if (selected.includes('photos')) {
           cols = cols.filter(c => c !== 'photos');
@@ -877,6 +877,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const LABELS = {
           created_by_email:'Créé par',
+          modified_by_email:'Modifié par',
           etage:'Étage', chambre:'Chambre', numero:'N°', lot:'Lot',
           intitule:'Intitulé', description:'Description', etat:'État',
           entreprise:'Entreprise', localisation:'Localisation',
@@ -887,6 +888,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Largeurs de base (ajustées ensuite pour rentrer dans la page)
         const BASE = {
           created_by_email: 120,
+          modified_by_email: 120,
           etage: 50, chambre: 60, numero: 36, lot: 70,
           intitule: 140, description: 260, etat: 72,
           entreprise: 100, localisation: 120,

--- a/routes/export.js
+++ b/routes/export.js
@@ -41,6 +41,13 @@ router.get('/', async (req, res) => {
   let cols = rows.length > 0 ? Object.keys(rows[0]) : [];
   // On retire les identifiants numériques inutiles
   cols = cols.filter(c => c !== 'created_by' && c !== 'modified_by');
+
+  // Rétro-compatibilité : si le client envoie "modified_by", on mappe vers "modified_by_email"
+  if (req.query.columns) {
+    let sel = Array.isArray(req.query.columns) ? req.query.columns.slice() : [req.query.columns];
+    sel = sel.map(c => c === 'modified_by' ? 'modified_by_email' : c);
+    cols = sel.filter(c => cols.includes(c)).length ? sel.filter(c => cols.includes(c)) : cols;
+  }
   if (rows[0] && rows[0].photos !== undefined && !cols.includes('photos')) {
     cols.push('photos');
   }


### PR DESCRIPTION
## Summary
- expose `modified_by_email` in PDF/Excel exports
- update UI to toggle "Modifié par (email)"
- map legacy `modified_by` query to `modified_by_email`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b58f5e18a88328a9db1eee99d509cd