### PR TITLE
feat: improve levee handling and exports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Auth Demo</title>
   <link rel="stylesheet" href="styles.css" />
+  <!-- Styles spécifiques à la section Levée pour gérer le clair/sombre -->
   <style>
     .section-levee {
       border: 1px solid #e2e8f0;

--- a/public/script.js
+++ b/public/script.js
@@ -382,8 +382,9 @@ document.addEventListener('DOMContentLoaded', () => {
           }).join('') : ''}
           <fieldset class="section-levee" style="margin-top:8px;">
             <legend>Levée</legend>
-            <div>Fait par : <strong>${user?.email || (bulle.levee_fait_par_email || '—')}</strong></div>
-            <input type="hidden" name="levee_fait_par" value="${user?.id || ''}">
+            <label>Fait par :
+              <input type="text" name="levee_fait_par_email" value="${user?.email || bulle.levee_fait_par_email || ''}" readonly>
+            </label><br>
             <label>Fait le :
               <input type="date" name="levee_fait_le" value="${bulle.levee_fait_le ? bulle.levee_fait_le.substring(0,10) : ''}">
             </label><br>
@@ -751,6 +752,21 @@ document.addEventListener('DOMContentLoaded', () => {
         <input type="text" name="observation" placeholder="Observation" /><br>
         <input type="date" name="date_butoir" /><br>
         <input type="file" name="media" multiple accept="image/*,video/*" /><br>
+        <fieldset class="section-levee" style="margin-top:8px;">
+          <legend>Levée</legend>
+          <label>Fait par :
+            <input type="text" name="levee_fait_par_email" value="${user?.email || ''}" readonly>
+          </label><br>
+          <label>Fait le :
+            <input type="date" name="levee_fait_le">
+          </label><br>
+          <label>Commentaire levée :
+            <textarea name="levee_commentaire" placeholder="Commentaire"></textarea>
+          </label><br>
+          <label>Photo Levée :
+            <input type="file" name="levee_media" multiple accept="image/*">
+          </label>
+        </fieldset>
         <button type="submit">✅ Ajouter</button>
         <button type="button" onclick="closePopups()">Annuler</button>
       `;

--- a/routes/export.js
+++ b/routes/export.js
@@ -66,6 +66,12 @@ router.get('/', async (req, res) => {
   // --- BEGIN : Réordonnage fixe des colonnes ---
   // On veut d'abord ces colonnes dans cet ordre :
   const desiredOrder = [
+    'created_by_email',
+    'modified_by_email',
+    'levee_fait_par_email',
+    'levee_fait_le',
+    'levee_commentaire',
+    'levee_photos',
     'etage',
     'chambre',
     'numero',
@@ -76,13 +82,7 @@ router.get('/', async (req, res) => {
     'etat',
     'lot',
     'entreprise',
-    'localisation',
-    'created_by_email',
-    'modified_by_email',
-    'levee_fait_par_email',
-    'levee_fait_le',
-    'levee_commentaire',
-    'levee_photos'
+    'localisation'
   ];
   // On filtre pour ne garder que celles qui existent encore dans cols
   const head = desiredOrder.filter(c => cols.includes(c));


### PR DESCRIPTION
## Summary
- show Levée section with read-only author, date, comment and photo inputs
- handle Levée data server-side to avoid integer parsing errors
- reorder export columns and include Levée photo links
- document Levée section styles for dark mode

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b6b4a770ac83288d70e6fddae1374c