### PR TITLE
Allow levee_photo media type and theme-aware Levée styles

### DIFF
--- a/migrations/016_bulle_media_type_check.sql
+++ b/migrations/016_bulle_media_type_check.sql
@@ -1,0 +1,6 @@
+BEGIN;
+ALTER TABLE bulle_media DROP CONSTRAINT bulle_media_type_check;
+ALTER TABLE bulle_media
+  ADD CONSTRAINT bulle_media_type_check
+  CHECK (type IN ('photo','video','levee_photo'));
+COMMIT;

--- a/public/index.html
+++ b/public/index.html
@@ -5,31 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Auth Demo</title>
   <link rel="stylesheet" href="styles.css" />
-  <!-- Styles spécifiques à la section Levée pour gérer le clair/sombre -->
-  <style>
-    .section-levee {
-      border: 1px solid #e2e8f0;
-      border-radius: 8px;
-      padding: 8px;
-      background: #f8fafc;
-      margin-top: 8px;
-    }
-    .section-levee label { display:block; margin-top:6px; }
-    @media (prefers-color-scheme: dark) {
-      .section-levee {
-        border-color: #334155;
-        background: rgba(255,255,255,0.06);
-        color: #e2e8f0;
-      }
-      .section-levee input,
-      .section-levee textarea,
-      .section-levee select {
-        background: rgba(255,255,255,0.08);
-        color: #e2e8f0;
-        border: 1px solid #475569;
-      }
-    }
-  </style>
 </head>
 <body>
   <div id="sidebar-holder"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -380,7 +380,7 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
             }
           }).join('') : ''}
-          <fieldset class="section-levee" style="margin-top:8px;">
+          <fieldset class="section-levee">
             <legend>Levée</legend>
             <label>Fait par :
               <input type="text" name="levee_fait_par_email" value="${user?.email || bulle.levee_fait_par_email || ''}" readonly>
@@ -752,7 +752,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <input type="text" name="observation" placeholder="Observation" /><br>
         <input type="date" name="date_butoir" /><br>
         <input type="file" name="media" multiple accept="image/*,video/*" /><br>
-        <fieldset class="section-levee" style="margin-top:8px;">
+        <fieldset class="section-levee">
           <legend>Levée</legend>
           <label>Fait par :
             <input type="text" name="levee_fait_par_email" value="${user?.email || ''}" readonly>

--- a/public/styles.css
+++ b/public/styles.css
@@ -319,3 +319,18 @@ button:hover {
   }
 
 }
+
+:root { --card-bg:#f8fafc; --card-border:#e2e8f0; }
+html[data-theme="dark"], body[data-theme="dark"]{ --card-bg:rgba(255,255,255,0.06); --card-border:#334155; }
+.section-levee{ border:1px solid var(--card-border); border-radius:8px; padding:8px; background:var(--card-bg); margin-top:8px; color:inherit; }
+.section-levee input, .section-levee textarea, .section-levee select{ background:transparent; color:inherit; border:1px solid var(--card-border); }
+
+.section-levee legend { font-weight: 600; margin-bottom: 6px; }
+.section-levee input, .section-levee textarea, .section-levee select { width: 100%; }
+.section-levee input::placeholder, .section-levee textarea::placeholder {
+  color: inherit; opacity: .7;
+}
+.section-levee input:focus, .section-levee textarea:focus, .section-levee select:focus {
+  outline: none; box-shadow: 0 0 0 2px var(--card-border);
+}
+

--- a/schema.sql
+++ b/schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE bulle_media (
   id SERIAL PRIMARY KEY,
   bulle_id INTEGER NOT NULL REFERENCES bulles(id) ON DELETE CASCADE,
-  type TEXT NOT NULL CHECK (type IN ('photo','video','levee_photo')),
+  type TEXT NOT NULL CHECK (type IN ('photo', 'video', 'levee_photo')),
   path TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## Summary
- allow `levee_photo` in `bulle_media` type constraint through new migration and schema
- move Levée section styles to CSS with theme variables
- remove inline Levée styles in index and script templates
- refine Levée section placeholders, focus and field width for readability

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b6bb2a0c608328ab14b4ff226e509e