### PR TITLE
Regroup levée columns and add theme toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,7 @@
   <div id="app-container" style="display:none;">
     <h1>Bienvenue</h1>
     <button id="logoutBtn">Déconnexion</button>
+    <button id="themeToggle" type="button" title="Basculer clair/sombre">🌓</button>
     <nav>
       <a href="selection.html" id="nav-selection" class="btn btn-primary">
         Gestion des tâches
@@ -86,12 +87,12 @@
       <label><input type="checkbox" name="col" value="numero" checked> N°</label>
       <label><input type="checkbox" name="col" value="lot" checked> Lot</label>
       <label><input type="checkbox" name="col" value="intitule" checked> Intitulé</label>
-      <label><input type="checkbox" name="col" value="description" checked> Description</label>
+      <label><input type="checkbox" name="col" value="description"> Description</label>
       <label><input type="checkbox" name="col" value="etat" checked> État</label>
       <label><input type="checkbox" name="col" value="entreprise" checked> Entreprise</label>
-      <label><input type="checkbox" name="col" value="localisation" checked> Localisation</label>
+      <label><input type="checkbox" name="col" value="localisation"> Localisation</label>
       <label><input type="checkbox" name="col" value="observation" checked> Observation</label>
-      <label><input type="checkbox" name="col" value="date_butoir" checked> Date butoir</label>
+      <label><input type="checkbox" name="col" value="date_butoir"> Date butoir</label>
       <label><input type="checkbox" name="col" value="photos" checked> Photos (tous les liens)</label>
       <label><input type="checkbox" name="col" value="videos" checked> Vidéos (tous les liens)</label>
       <label><input type="checkbox" name="col" value="levee_fait_par_email" checked> Levée – Fait par</label>
@@ -110,5 +111,29 @@
 
   <script src="script.js"></script>
   <script src="selection.js"></script>
+  <script>
+    (function() {
+      const KEY = 'theme';
+      const root = document.documentElement; // <html>
+      const btn = document.getElementById('themeToggle');
+
+      function apply(theme) {
+        root.setAttribute('data-theme', theme);
+        localStorage.setItem(KEY, theme);
+        if (btn) btn.setAttribute('aria-label', theme === 'dark' ? 'Passer en clair' : 'Passer en sombre');
+      }
+
+      const saved = localStorage.getItem(KEY);
+      const initial = saved || root.getAttribute('data-theme') || 'light';
+      apply(initial);
+
+      if (btn) {
+        btn.addEventListener('click', () => {
+          const current = root.getAttribute('data-theme') || 'light';
+          apply(current === 'dark' ? 'light' : 'dark');
+        });
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -897,17 +897,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const selected = getCheckedColumns();
 
-        // Ordre lisible + "photos" toujours en dernier si cochée
-        const ORDER = ['created_by_email','modified_by_email','levee_fait_par_email','levee_fait_le','levee_commentaire','levee_photos','etage','chambre','numero','lot','intitule','description','etat','entreprise','localisation','observation','date_butoir','photos'];
+        // Ordre: Photos juste avant le bloc Levée ; Levée = Fait par, Commentaire, (puis Photos de levée)
+        const ORDER = [
+          'created_by_email','modified_by_email',
+          'etage','chambre','numero','lot','intitule','description','etat','entreprise','localisation','observation','date_butoir',
+          'photos',
+          'levee_fait_par_email','levee_commentaire','levee_photos','levee_fait_le'
+        ];
         let cols = ORDER.filter(c => selected.includes(c));
-        if (selected.includes('levee_photos')) {
-          cols = cols.filter(c => c !== 'levee_photos');
-          cols.push('levee_photos');
-        }
-        if (selected.includes('photos')) {
-          cols = cols.filter(c => c !== 'photos');
-          cols.push('photos');
-        }
+        // On impose l’ordre exact défini ci-dessus, sans repousser "photos" en dernier
 
         if (!window.jspdf || !window.jspdf.jsPDF) {
           alert('Export PDF indisponible (librairies non chargées)');

--- a/routes/export.js
+++ b/routes/export.js
@@ -66,23 +66,11 @@ router.get('/', async (req, res) => {
   // --- BEGIN : Réordonnage fixe des colonnes ---
   // On veut d'abord ces colonnes dans cet ordre :
   const desiredOrder = [
-    'created_by_email',
-    'modified_by_email',
-    'levee_fait_par_email',
-    'levee_fait_le',
-    'levee_commentaire',
-    'levee_photos',
-    'etage',
-    'chambre',
-    'numero',
-    'intitule',
-    'photos',
-    'videos',
-    'photo',
-    'etat',
-    'lot',
-    'entreprise',
-    'localisation'
+    'created_by_email','modified_by_email',
+    'etage','chambre','numero','lot','intitule','description','etat','entreprise','localisation','observation','date_butoir',
+    'photos', // <= juste avant le bloc Levée
+    'levee_fait_par_email','levee_commentaire','levee_photos','levee_fait_le',
+    'videos','photo'
   ];
   // On filtre pour ne garder que celles qui existent encore dans cols
   const head = desiredOrder.filter(c => cols.includes(c));
@@ -90,30 +78,7 @@ router.get('/', async (req, res) => {
   const tail = cols.filter(c => !desiredOrder.includes(c));
   cols = [...head, ...tail];
   // --- END : Réordonnage fixe des colonnes ---
-
-  if (req.query.columns) {
-    const sel = Array.isArray(req.query.columns)
-      ? req.query.columns
-      : [req.query.columns];
-    cols = sel.filter(c => cols.includes(c));
-
-    // repositionner photos & videos juste avant 'etat'
-    if (cols.includes('photos') && cols.includes('etat')) {
-      cols = cols.filter(c => c !== 'photos');
-      const idx = cols.indexOf('etat');
-      cols.splice(idx, 0, 'photos');
-    }
-    if (cols.includes('videos') && cols.includes('etat')) {
-      cols = cols.filter(c => c !== 'videos');
-      const idx = cols.indexOf('etat');
-      cols.splice(idx, 0, 'videos');
-    }
-    if (cols.includes('levee_photos') && cols.includes('etat')) {
-      cols = cols.filter(c => c !== 'levee_photos');
-      const idx = cols.indexOf('etat');
-      cols.splice(idx, 0, 'levee_photos');
-    }
-  }
+  // plus de repositionnement automatique : on respecte desiredOrder
 
   const format = (req.query.format || 'csv').toLowerCase();
   if (format === 'csv') {


### PR DESCRIPTION
## Summary
- default unchecked Description, Localisation and Date butoir in export options
- group levée fields after Photos for consistent export order across PDF/CSV/Excel
- add light/dark theme toggle with localStorage persistence

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b6c41b11208328ab80551921192401