### PR TITLE
Format dates in French and fix theme toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -111,29 +111,5 @@
 
   <script src="script.js"></script>
   <script src="selection.js"></script>
-  <script>
-    (function() {
-      const KEY = 'theme';
-      const root = document.documentElement; // <html>
-      const btn = document.getElementById('themeToggle');
-
-      function apply(theme) {
-        root.setAttribute('data-theme', theme);
-        localStorage.setItem(KEY, theme);
-        if (btn) btn.setAttribute('aria-label', theme === 'dark' ? 'Passer en clair' : 'Passer en sombre');
-      }
-
-      const saved = localStorage.getItem(KEY);
-      const initial = saved || root.getAttribute('data-theme') || 'light';
-      apply(initial);
-
-      if (btn) {
-        btn.addEventListener('click', () => {
-          const current = root.getAttribute('data-theme') || 'light';
-          apply(current === 'dark' ? 'light' : 'dark');
-        });
-      }
-    })();
-  </script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -975,7 +975,8 @@ document.addEventListener('DOMContentLoaded', () => {
           if (c === 'created_by_email') return resolveCreatedBy(row);
           if (c === 'modified_by_email') return resolveModifiedBy(row);
           if (c === 'levee_fait_par_email') return localPart(row.levee_fait_par_email);
-          if (c === 'levee_fait_le') return formatDateShort(row.levee_fait_le);
+          if (c === 'levee_fait_le') return formatDateFR(row.levee_fait_le);
+          if (c === 'date_butoir')  return formatDateFR(row.date_butoir);
           return softText(row[c], (c === 'description' || c === 'levee_commentaire') ? 500 : 220);
         }));
 
@@ -990,11 +991,12 @@ document.addEventListener('DOMContentLoaded', () => {
         // Titre
         doc.setFontSize(12);
         // Helpers: format date courte + libellé d'étage affiché
-        function formatDateShort(v){
+        function formatDateFR(v) {
           if (!v) return '—';
-          // v peut être string ISO ou Date -> on force en string puis YYYY-MM-DD
-          const s = typeof v === 'string' ? v : (new Date(v)).toISOString();
-          return s.slice(0,10);
+          const d = new Date(v);
+          if (isNaN(d)) return '—';
+          // ex: "02 sept 2025" (retire le point abréviation éventuel)
+          return d.toLocaleDateString('fr-FR', { day:'2-digit', month:'short', year:'numeric' }).replace('.', '');
         }
         const chantierNom = chantierSelect.options[chantierSelect.selectedIndex]?.text || chantierSelect.value;
         const etageLabel  = etageSelect.options[etageSelect.selectedIndex]?.text || etageSelect.value;

--- a/public/sidebar.html
+++ b/public/sidebar.html
@@ -4,9 +4,6 @@
     <span id="sidebar-user">—</span>
     <button id="sidebar-logout">Déconnexion</button>
   </div>
-  <div class="theme-switch">
-    <button id="theme-toggle" onclick="toggleTheme()" aria-pressed="false" title="Thème clair/sombre">☀️ / 🌙</button>
-  </div>
   <ul>
     <li><a href="/index.html">Bulles</a></li>
     <li><a href="/selection.html">Interventions</a></li>

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,36 +1,30 @@
-/* Thème clair/sombre persistant */
-(function(){
-  const KEY='rb_theme';
-  const root=document.documentElement;
+// Gestion du thème clair/sombre
+(() => {
+  const KEY = 'theme';
 
-  function apply(theme){
-    if(theme==='dark'){ root.classList.add('dark-theme'); }
-    else{ root.classList.remove('dark-theme'); }
-  }
+  const getInitial = () =>
+    localStorage.getItem(KEY)
+    || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
-  // Choix initial : localStorage > prefers-color-scheme > light
-  let initial = localStorage.getItem(KEY);
-  if(!initial){
-    try{
-      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-      initial = prefersDark ? 'dark' : 'light';
-    }catch(_){ initial='light'; }
-  }
-  apply(initial);
-
-  // Expose bascule globale pour la sidebar
-  window.toggleTheme = function(){
-    const now = root.classList.contains('dark-theme') ? 'light' : 'dark';
-    localStorage.setItem(KEY, now);
-    apply(now);
-    // Mettre à jour l'état ARIA du bouton si présent
-    const btn = document.getElementById('theme-toggle');
-    if(btn){ btn.setAttribute('aria-pressed', now==='dark' ? 'true' : 'false'); }
+  const apply = (theme) => {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.body.setAttribute('data-theme', theme);
+    localStorage.setItem(KEY, theme);
   };
 
-  // (Optionnel) synchroniser l'état ARIA dès le chargement
-  const initBtn = document.getElementById('theme-toggle');
-  if (initBtn) {
-    initBtn.setAttribute('aria-pressed', initial==='dark' ? 'true' : 'false');
-  }
+  // Appliquer au chargement
+  document.addEventListener('DOMContentLoaded', () => {
+    apply(getInitial());
+
+    const btn = document.getElementById('themeToggle');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        const current = document.documentElement.getAttribute('data-theme') || 'light';
+        const next = current === 'dark' ? 'light' : 'dark';
+        apply(next);
+        btn.setAttribute('aria-label', next === 'dark' ? 'Passer en clair' : 'Passer en sombre');
+      });
+    }
+  });
 })();
+


### PR DESCRIPTION
## Summary
- Format export dates in French for "Levée – Fait le" and "Date butoir" columns using a new `formatDateFR` helper.
- Centralize theme switching logic in `theme.js` to apply the theme to `<html>` and `<body>` and hook the `#themeToggle` button.
- Remove inline theme script and sidebar toggle to rely solely on the global handler.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b6eb0b41708328b2aed5c389ec010d