### PR TITLE
Restore dark/light theme toggle in sidebar

### DIFF
--- a/public/sidebar.html
+++ b/public/sidebar.html
@@ -4,6 +4,9 @@
     <span id="sidebar-user">—</span>
     <button id="sidebar-logout">Déconnexion</button>
   </div>
+  <div class="theme-switch">
+    <button id="themeToggle" aria-label="Passer en sombre">☀️ / 🌙</button>
+  </div>
   <ul>
     <li><a href="/index.html">Bulles</a></li>
     <li><a href="/selection.html">Interventions</a></li>

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,30 +1,51 @@
 // Gestion du thème clair/sombre
 (() => {
   const KEY = 'theme';
+  const root = document.documentElement;
+  const body = document.body;
 
-  const getInitial = () =>
-    localStorage.getItem(KEY)
-    || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-
-  const apply = (theme) => {
-    document.documentElement.setAttribute('data-theme', theme);
-    document.body.setAttribute('data-theme', theme);
+  function apply(theme) {
+    root.setAttribute('data-theme', theme);
+    body.setAttribute('data-theme', theme);
     localStorage.setItem(KEY, theme);
-  };
-
-  // Appliquer au chargement
-  document.addEventListener('DOMContentLoaded', () => {
-    apply(getInitial());
-
     const btn = document.getElementById('themeToggle');
     if (btn) {
-      btn.addEventListener('click', () => {
-        const current = document.documentElement.getAttribute('data-theme') || 'light';
-        const next = current === 'dark' ? 'light' : 'dark';
-        apply(next);
-        btn.setAttribute('aria-label', next === 'dark' ? 'Passer en clair' : 'Passer en sombre');
-      });
+      btn.setAttribute(
+        'aria-label',
+        theme === 'dark' ? 'Passer en clair' : 'Passer en sombre'
+      );
+      btn.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
     }
+  }
+
+  function initialTheme() {
+    return (
+      localStorage.getItem(KEY) ||
+      (window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light')
+    );
+  }
+
+  function bindToggleIfNeeded() {
+    const btn = document.getElementById('themeToggle');
+    if (!btn || btn.dataset.bound === '1') return;
+    btn.addEventListener('click', () => {
+      const current = root.getAttribute('data-theme') || 'light';
+      const next = current === 'dark' ? 'light' : 'dark';
+      apply(next);
+    });
+    btn.dataset.bound = '1';
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    apply(initialTheme());
+    // Premier essai immédiat
+    bindToggleIfNeeded();
+    // Filet de sécurité si la sidebar est injectée après coup
+    const obs = new MutationObserver(() => bindToggleIfNeeded());
+    obs.observe(document.body, { childList: true, subtree: true });
   });
 })();
 


### PR DESCRIPTION
## Summary
- add theme toggle button in sidebar
- persist theme with data-theme attribute and localStorage
- bind toggle handler even when sidebar loads late

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b6f463c9548328a08d4a0c1e91ff71