### PR TITLE
feat: handle levee data in dedicated popup

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -576,6 +576,15 @@ document.addEventListener('DOMContentLoaded', () => {
         fd.append('levee_fait_par', user?.id || '');
         const files = form.querySelector('input[name="levee_media"]').files;
         for (const file of files) fd.append('levee_media', file);
+        // Preserve existing bubble fields to avoid clearing them during PUT
+        fd.append('description', bulle.description ?? '');
+        fd.append('intitule', bulle.intitule ?? '');
+        fd.append('etat', bulle.etat ?? '');
+        fd.append('lot', bulle.lot ?? '');
+        fd.append('entreprise_id', bulle.entreprise_id ?? '');
+        fd.append('localisation', bulle.localisation ?? '');
+        fd.append('observation', bulle.observation ?? '');
+        fd.append('date_butoir', bulle.date_butoir ? bulle.date_butoir.substring(0,10) : '');
         fetch(`/api/bulles/${bulle.id}`, {
           method: 'PUT',
           credentials: 'include',


### PR DESCRIPTION
## Summary
- move levee fields from main bubble form to dedicated popup
- allow updating levee data via separate dialog and API call

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b7ff66e1d48328b55d518869d0d9b9