### PR TITLE
Remove modal background freezing and overlay

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -514,7 +514,6 @@ document.addEventListener('DOMContentLoaded', () => {
       if (typeof content === 'string') popup.innerHTML = content;
       else popup.appendChild(content);
       document.body.appendChild(popup);
-      document.body.classList.add("modal-open");
 
       function reposition() {
         if (!isMobile || !window.visualViewport) return;
@@ -537,7 +536,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         p.remove();
       });
-      document.body.classList.remove('modal-open');
     }
     // rendre la fonction accessible depuis l’attribut onclick inline
     window.closePopups = closePopups;

--- a/public/styles.css
+++ b/public/styles.css
@@ -20,10 +20,6 @@ html, body{
   color: var(--text);
 }
 
-body.modal-open {
-  overflow: hidden;
-  touch-action: none;
-}
 a{ color: var(--link); }
 small, .muted, .text-muted{ color: var(--muted); }
 
@@ -281,7 +277,7 @@ button:hover {
     position: fixed;
     inset: 0;
     z-index: 9999;
-    background: rgba(0,0,0,0.55);
+    background: transparent;
     display: flex;
     align-items: stretch;
     justify-content: stretch;
@@ -291,15 +287,15 @@ button:hover {
   .popup .popup-content {
     width: 100vw;
     height: 100dvh;
-    height: -webkit-fill-available;
     max-width: none;
     max-height: none;
     border-radius: 0;
     margin: 0;
     padding: env(safe-area-inset-top, 12px) 12px env(safe-area-inset-bottom, 12px);
-    padding-bottom: max(env(safe-area-inset-bottom, 12px), 16px);
     overflow: auto;
     box-shadow: none;
+    background: var(--card-bg);
+    color: inherit;
   }
 
   .popup img.preview,


### PR DESCRIPTION
## Summary
- stop adding/removing modal-open on body so background remains scrollable
- remove modal-open CSS rule and transparentize mobile popup overlay

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b83c2faac8832880ac102c41d8ee3e