### PR TITLE
feat: improve mobile popups

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -497,6 +497,7 @@ document.addEventListener('DOMContentLoaded', () => {
         popup.style.top = '0';
         popup.style.width = '100vw';
         popup.style.height = '100dvh';
+        popup.style.zIndex = '9999';
       } else {
         popup.style.left = `${x + 40}px`;
         popup.style.top = `${y}px`;
@@ -848,9 +849,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function getZoomFactor() {
-      if (window.visualViewport) {
-        return window.devicePixelRatio * (window.visualViewport.scale || 1);
-      }
       return window.devicePixelRatio || 1;
     }
 
@@ -1071,7 +1069,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     window.addEventListener('resize', ajusterTailleBulles);
     window.addEventListener('orientationchange', ajusterTailleBulles);
-    if (window.visualViewport) window.visualViewport.addEventListener('resize', ajusterTailleBulles);
   }
 
   loginForm.addEventListener('submit', async (e) => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -287,18 +287,22 @@ button:hover {
   }
 
   .popup .popup-content {
-    background: var(--card-bg, #ffffff);
-    color: inherit;
     box-sizing: border-box;
+    background: var(--card-bg, #fff) !important;
+    color: inherit;
     width: 100vw;
+    min-height: 100svh;
     height: 100dvh;
-    height: -webkit-fill-available;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
     display: flex;
     flex-direction: column;
     gap: 8px;
     padding: env(safe-area-inset-top, 12px) 12px env(safe-area-inset-bottom, 12px);
+    border-radius: 0;
+    margin: 0;
+    box-shadow: none;
   }
 
   .popup img.preview,
@@ -311,8 +315,7 @@ button:hover {
     font-size: 16px;
   }
 
-  .popup button,
-  .filter-group .filter-control button {
+  .popup button {
     font-size: 16px;
     padding: 10px;
     width: 100%;
@@ -323,10 +326,6 @@ button:hover {
   .popup .section-levee textarea,
   .popup .section-levee select {
     width: 100%;
-  }
-
-  html, body {
-    overscroll-behavior: contain;
   }
 
   .bulle {


### PR DESCRIPTION
## Summary
- simplify mobile popup positioning and remove visualViewport scaling
- ensure mobile styles are opaque, scrollable, and full screen
- add robust viewport height handling and inertial scrolling inside mobile popup; move overscroll containment to popup content

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check public/script.js`


------
https://chatgpt.com/codex/tasks/task_b_68b845bd479c83289f122f6ae84dc148