### PR TITLE
Refactor sidebar rendering and integrate with login

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1117,6 +1117,10 @@ document.addEventListener('DOMContentLoaded', () => {
       loginError.textContent = '';
       loginContainer.style.display = 'none';
       appContainer.style.display   = 'block';
+      // Render the sidebar now that we are authenticated
+      if (window.renderSidebar) {
+        try { await window.renderSidebar(); } catch(_){ }
+      }
       await initApp();
     } else {
       loginError.textContent = 'Échec de la connexion';


### PR DESCRIPTION
## Summary
- Implement dynamic sidebar rendering based on authenticated session
- Invoke sidebar rendering after successful login
- Restore `with-sidebar` body class and burger menu overlay
- Scope theme toggle wiring to the sidebar to avoid duplicate listeners

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check public/sidebar.js`
- `node --check public/script.js`


------
https://chatgpt.com/codex/tasks/task_b_68b94bb101cc83289b91f4307bc9eb1e