### PR TITLE
feat: soften sidebar toggle visibility

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -440,3 +440,14 @@ html[data-theme="dark"], body[data-theme="dark"]{ --card-bg:rgba(255,255,255,0.0
   }
 }
 
+/* Bouton burger légèrement transparent pour ne pas masquer le logo */
+#sidebar-toggle {
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+}
+
+#sidebar-toggle:hover,
+#sidebar-toggle:focus {
+  opacity: 1;
+}
+


### PR DESCRIPTION
## Summary
- make sidebar toggle semi-transparent and animate opacity on hover/focus

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b9571255748328a220e03a00ca9999