### PR TITLE
Améliore la génération du filigrane PDF

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -91,6 +91,23 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
+    async function bakeAlphaToJPEG(imgData, alpha = 0.15) {
+      const srcImg = new Image();
+      return await new Promise((resolve) => {
+        srcImg.onload = () => {
+          const canvas = document.createElement('canvas');
+          canvas.width = srcImg.naturalWidth;
+          canvas.height = srcImg.naturalHeight;
+          const ctx = canvas.getContext('2d');
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          ctx.globalAlpha = alpha;
+          ctx.drawImage(srcImg, 0, 0);
+          resolve(canvas.toDataURL('image/jpeg', 0.8));
+        };
+        srcImg.src = imgData;
+      });
+    }
+
     async function getImageRatio(dataUrl) {
       return await new Promise((resolve) => {
         const img = new Image();
@@ -1031,11 +1048,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const resp = await fetch('/img/brh-logo.png', { credentials: 'include' });
         if (resp.ok) {
           const blob = await resp.blob();
-          watermark = await new Promise((resolve) => {
-            const fr = new FileReader();
-            fr.onload = () => resolve(fr.result);
-            fr.readAsDataURL(blob);
+          const dataURL = await new Promise((resolve) => {
+            const r = new FileReader();
+            r.onload = () => resolve(r.result);
+            r.readAsDataURL(blob);
           });
+          watermark = await bakeAlphaToJPEG(dataURL, 0.18);
         }
         const ratio   = watermark ? await getImageRatio(watermark) : 1;
         const targetW = pageW * 0.60;
@@ -1108,17 +1126,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             h.cell.text = []; // pas de texte dans la cellule
           },
-          didDrawPage: () => {
-            if (!watermark) return;
-            const hasGState = typeof doc.GState === 'function' && typeof doc.setGState === 'function';
-            if (hasGState) {
-              const gs = new doc.GState({ opacity: 0.15 });
-              doc.setGState(gs);
-            }
-            doc.addImage(watermark, 'PNG', posX, posY, targetW, targetH);
-            if (hasGState) {
-              const gsNorm = new doc.GState({ opacity: 1 });
-              doc.setGState(gsNorm);
+          didDrawPage: (data) => {
+            if (watermark) {
+              doc.addImage(watermark, 'JPEG', posX, posY, targetW, targetH);
             }
           }
         });


### PR DESCRIPTION
## Summary
- Prépare le logo en JPEG avec opacité intégrée pour le filigrane des exports PDF
- Charge le filigrane une seule fois et le dessine après le tableau sans état graphique

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b9663f8b0c8328ab845ec09bf1c0ec