### PR TITLE
Centralize theme toggling and remove duplicate handlers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
       <img src="/img/brh-logo.png" class="brand-logo" alt="Bâti Rénov Hôtellerie">
       <div class="brand-actions">
         <button id="logoutBtn">Déconnexion</button>
-        <button id="themeToggle" data-theme-toggle type="button" title="Basculer clair/sombre">🌓</button>
+        <button id="themeToggleIndex" data-theme-toggle type="button" title="Basculer clair/sombre">🌓</button>
       </div>
     </header>
     <h1>Bienvenue</h1>

--- a/public/sidebar.html
+++ b/public/sidebar.html
@@ -7,7 +7,7 @@
     <button id="sidebar-logout">Déconnexion</button>
   </div>
   <div class="theme-switch">
-    <button id="themeToggle" data-theme-toggle aria-label="Passer en sombre" aria-pressed="false">☀️ / 🌙</button>
+    <button id="sidebarThemeToggle" data-theme-toggle aria-label="Basculer clair/sombre" aria-pressed="false">☀️ / 🌙</button>
   </div>
   <ul>
     <li><a href="/index.html">Bulles</a></li>

--- a/public/sidebar.js
+++ b/public/sidebar.js
@@ -98,18 +98,6 @@
     };
     document.addEventListener('keydown', keyHandler);
 
-    // Re-wire theme toggle buttons scoped to the sidebar
-    holder.querySelectorAll('[data-theme-toggle]').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const root = document.documentElement;
-        const current = root.getAttribute('data-theme') || 'light';
-        const next = current === 'dark' ? 'light' : 'dark';
-        root.setAttribute('data-theme', next);
-        document.body.setAttribute('data-theme', next);
-        try { localStorage.setItem('theme', next); } catch (_){ }
-        btn.setAttribute('aria-label', next === 'dark' ? 'Passer en clair' : 'Passer en sombre');
-      });
-    });
   }
 
   // Expose globally so pages can call it after login

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,43 +1,36 @@
-// Gestion du thème clair/sombre (robuste avec délégation d’événement)
-(() => {
-  const KEY = 'theme';
+// Gestion centralisée du thème (charge/init + delegation)
+(function () {
   const root = document.documentElement;
-  const body = document.body;
 
-  const SELECTOR = '[data-theme-toggle], #themeToggle, .themeToggle';
-
-  const getInitial = () =>
-    localStorage.getItem(KEY) ||
-    (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light');
-
-  function updateAllButtons(theme) {
-    document.querySelectorAll(SELECTOR).forEach(btn => {
-      btn.setAttribute('aria-label', theme === 'dark' ? 'Passer en clair' : 'Passer en sombre');
-      btn.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+  function applyTheme(mode) {
+    const val = mode === 'dark' ? 'dark' : 'light';
+    root.setAttribute('data-theme', val);
+    document.body.setAttribute('data-theme', val);
+    // compat CSS historique
+    document.body.classList.toggle('dark-theme', val === 'dark');
+    try { localStorage.setItem('theme', val); } catch (_) {}
+    // accessibilité (met à jour tous les boutons visibles)
+    document.querySelectorAll('[data-theme-toggle]').forEach(btn => {
+      btn.setAttribute('aria-label', val === 'dark' ? 'Passer en clair' : 'Passer en sombre');
+      btn.setAttribute('aria-pressed', String(val === 'dark'));
     });
   }
 
-  function applyTheme(theme) {
-    root.setAttribute('data-theme', theme);
-    body.setAttribute('data-theme', theme);
-    localStorage.setItem(KEY, theme);
-    updateAllButtons(theme);
+  // Thème initial : stockage → préférence système → clair
+  let saved = null;
+  try { saved = localStorage.getItem('theme'); } catch (_) {}
+  if (!saved && window.matchMedia) {
+    saved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
+  applyTheme(saved || 'light');
 
-  document.addEventListener('DOMContentLoaded', () => {
-    // Appliquer thème initial
-    applyTheme(getInitial());
-
-    // Délégation: clique sur n’importe quel bouton présent ou futur
-    document.addEventListener('click', (e) => {
-      const btn = e.target.closest(SELECTOR);
-      if (!btn) return;
-      const current = root.getAttribute('data-theme') || 'light';
-      const next = current === 'dark' ? 'light' : 'dark';
-      applyTheme(next);
-    });
+  // Delegation : fonctionne pour les boutons ajoutés dynamiquement (sidebar)
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-theme-toggle]');
+    if (!btn) return;
+    const current = root.getAttribute('data-theme') || 'light';
+    const next = current === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
   });
 })();
 


### PR DESCRIPTION
## Summary
- centralize dark/light theme management with event delegation
- remove redundant sidebar toggle bindings and unique toggle IDs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b97c430f2c8328b39c8995d7b3ad35