### PR TITLE
Replace obsolete bubble statuses

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -15,12 +15,11 @@
     </nav>
   </header>
   <main>
-    <section id="cards" style="display:flex; gap:20px; flex-wrap:wrap; justify-content:center;">
-      <div class="card" data-etat="attente">Attente: <span class="value">0</span></div>
-      <div class="card" data-etat="a_corriger">A corriger: <span class="value">0</span></div>
-      <div class="card" data-etat="corrige">Corrigé: <span class="value">0</span></div>
-      <div class="card" data-etat="validee">Validée: <span class="value">0</span></div>
-    </section>
+      <section id="cards" style="display:flex; gap:20px; flex-wrap:wrap; justify-content:center;">
+        <div class="card" data-etat="a_corriger">A corriger: <span class="value">0</span></div>
+        <div class="card" data-etat="corrige">Corrigé: <span class="value">0</span></div>
+        <div class="card" data-etat="levee">Levée: <span class="value">0</span></div>
+      </section>
     <section id="urgent" style="margin-top:30px;">
       <h2>Bulles urgentes</h2>
       <table>

--- a/public/index.html
+++ b/public/index.html
@@ -89,11 +89,9 @@
       <div class="filter-control">
         <select id="statusFilter">
           <option value="">-- Tous les statuts --</option>
-          <option value="attente">En attente</option>
           <option value="a_corriger">À corriger</option>
           <option value="corrige">Corrigé</option>
-          <option value="validee">Validé</option>
-          <option value="abandonnee">Abandonné</option>
+          <option value="levee">Levée</option>
         </select>
       </div>
     </div>

--- a/public/script.js
+++ b/public/script.js
@@ -353,11 +353,9 @@ document.addEventListener('DOMContentLoaded', () => {
           <textarea name="description" placeholder="Description">${bulle.description || ''}</textarea><br>
           <label>État :
             <select name="etat">
-              <option value="attente" ${bulle.etat === 'attente' ? 'selected' : ''}>🟡 En attente</option>
               <option value="a_corriger" ${bulle.etat === 'a_corriger' ? 'selected' : ''}>🔴 À corriger</option>
               <option value="corrige" ${bulle.etat === 'corrige' ? 'selected' : ''}>🔵 Corrigé</option>
-              <option value="validee" ${bulle.etat === 'validee' ? 'selected' : ''}>🟢 Validé</option>
-              <option value="abandonnee" ${bulle.etat === 'abandonnee' ? 'selected' : ''}>⚫ Abandonné</option>
+              <option value="levee" ${bulle.etat === 'levee' ? 'selected' : ''}>🟢 Levée</option>
             </select>
           </label><br>
           <label>Lot :
@@ -484,11 +482,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function getColorByEtat(etat) {
       switch (etat) {
-        case 'attente': return '#f1c40f';
         case 'a_corriger': return '#e74c3c';
         case 'corrige': return '#3498db';
-        case 'validee': return '#2ecc71';
-        case 'abandonnee': return '#7f8c8d';
+        case 'levee': return '#2ecc71';
         default: return '#e74c3c';
       }
     }
@@ -784,11 +780,9 @@ document.addEventListener('DOMContentLoaded', () => {
         <textarea name="description" placeholder="Description"></textarea><br>
         <label>État :
           <select name="etat">
-            <option value="attente" selected>🟡 En attente</option>
-            <option value="a_corriger">🔴 À corriger</option>
+            <option value="a_corriger" selected>🔴 À corriger</option>
             <option value="corrige">🔵 Corrigé</option>
-            <option value="validee">🟢 Validé</option>
-            <option value="abandonnee">⚫ Abandonné</option>
+            <option value="levee">🟢 Levée</option>
           </select>
         </label><br>
         <label>Lot :

--- a/public/selection.css
+++ b/public/selection.css
@@ -93,7 +93,7 @@ button:focus {
 .status-attente_validation { background: #09f; }
 
 .status-clos { background: #888; }
-.status-valide { background: #0a0; }
+.status-levee { background: #0a0; }
 
 /* États — couleurs plus douces et professionnelles */
 .status-ouvert {
@@ -116,7 +116,7 @@ button:focus {
   color: #37474F;            /* Gris anthracite */
 }
 
-.status-valide {
+.status-levee {
   background-color: #E8F5E9; /* Vert pâle */
   color: #1B5E20;            /* Vert foncé */
 }

--- a/public/selection.html
+++ b/public/selection.html
@@ -53,7 +53,7 @@
         <option value="en_cours">En cours</option>
         <option value="attente_validation">En attente de validation</option>
         <option value="clos">Clos</option>
-        <option value="valide">Validé</option>
+        <option value="levee">Levée</option>
         <option value="a_definir">À définir</option>
       </select>
     </label>

--- a/public/selection.js
+++ b/public/selection.js
@@ -46,7 +46,7 @@ const statusLabels = {
   en_cours: 'En cours',
   attente_validation: 'En attente de validation',
   clos: 'Clos',
-  valide: 'Validé',
+  levee: 'Levée',
   a_definir: 'À définir'
 };
 
@@ -458,7 +458,7 @@ function addEditRow(data = {}) {
     <option value="en_cours">En cours</option>
     <option value="attente_validation">En attente de validation</option>
     <option value="clos">Clos</option>
-    <option value="valide">Validé</option>
+    <option value="levee">Levée</option>
     <option value="a_definir">À définir</option>
   `;
   if (data.state) selState.value = data.state;

--- a/routes/bulles.js
+++ b/routes/bulles.js
@@ -419,11 +419,11 @@ router.get("/export/csv", async (req, res) => {
 });
 
 // GET /api/bulles/stats
-//   renvoie {attente: X, a_corriger: Y, corrige: Z, validee: W}
+//   renvoie {a_corriger: X, corrige: Y, levee: Z}
 router.get('/stats', async (req, res) => {
   try {
     const result = await pool.query("SELECT etat, COUNT(*) FROM bulles GROUP BY etat");
-    const stats = { attente: 0, a_corriger: 0, corrige: 0, validee: 0 };
+    const stats = { a_corriger: 0, corrige: 0, levee: 0 };
     result.rows.forEach(r => {
       stats[r.etat] = parseInt(r.count, 10);
     });
@@ -435,12 +435,12 @@ router.get('/stats', async (req, res) => {
 });
 
 // GET /api/bulles/urgent
-//   renvoie un tableau des 5 bulles où etat != 'validee'
+//   renvoie un tableau des 5 bulles où etat != 'levee'
 //   triées par due_date ASC
 router.get('/urgent', async (req, res) => {
   try {
     const result = await pool.query(
-      "SELECT id, description, date_butoir FROM bulles WHERE etat <> 'validee' ORDER BY date_butoir ASC LIMIT 5"
+      "SELECT id, description, date_butoir FROM bulles WHERE etat <> 'levee' ORDER BY date_butoir ASC LIMIT 5"
     );
     res.json(result.rows);
   } catch (err) {


### PR DESCRIPTION
## Summary
- replace bubble status `Validé` with `Levée`
- remove `Abandonné` and `En attente` states from UI and stats
- adjust dashboard, selection views, and backend stats/urgent queries

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c7e5970ba48328a8cac4179496bc2c