### PR TITLE
Mettre à jour l'état lors de l'enregistrement d'une levée

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -563,7 +563,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Preserve existing bubble fields to avoid clearing them during PUT
         fd.append('description', bulle.description ?? '');
         fd.append('intitule', bulle.intitule ?? '');
-        fd.append('etat', bulle.etat ?? '');
+        fd.append('etat', 'levee');
         fd.append('lot', bulle.lot ?? '');
         fd.append('localisation', bulle.localisation ?? '');
         fd.append('observation', bulle.observation ?? '');


### PR DESCRIPTION
## Summary
- défini l'état de la bulle à "levée" lors de l'enregistrement d'une levée afin de mettre à jour son statut automatiquement

## Testing
- non exécuté (non fourni)


------
https://chatgpt.com/codex/tasks/task_b_68d01e859cd483289caa40934fc843b2