### PR TITLE
Add admin plan phase editor and floor details endpoint

### DIFF
--- a/public/admin-phases.css
+++ b/public/admin-phases.css
@@ -1,0 +1,220 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fa;
+  --panel: #ffffff;
+  --border: #d9dce3;
+  --text: #1b2a4b;
+  --muted: #5b6887;
+  --accent1: rgba(255, 214, 0, 0.35);
+  --accent1-border: #f1c40f;
+  --accent2: rgba(255, 105, 180, 0.35);
+  --accent2-border: #e84393;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.phase-tool {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 20px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.phase-tool__header h1 {
+  margin: 0 0 8px 0;
+  font-size: 2rem;
+}
+
+.phase-tool__floor {
+  margin: 0;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.phase-tool__panel,
+.phase-tool__coordinates,
+.phase-tool__export {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.04);
+}
+
+.phase-tool__instructions p {
+  margin: 0 0 12px 0;
+  color: var(--muted);
+}
+
+.phase-tool__status {
+  margin-bottom: 12px;
+  font-weight: 600;
+  color: #c0392b;
+}
+
+.phase-tool__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.phase-button {
+  border: 1px solid var(--border);
+  background: #f4f6fb;
+  color: var(--text);
+  font-weight: 600;
+  padding: 10px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.phase-button:hover {
+  background: #e7ecfa;
+}
+
+.phase-button--active {
+  background: #1b2a4b;
+  border-color: #1b2a4b;
+  color: #ffffff;
+}
+
+.phase-button--ghost {
+  border-style: dashed;
+  background: transparent;
+  color: var(--muted);
+}
+
+.phase-tool__plan {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 360px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.03);
+}
+
+.plan-container {
+  position: relative;
+  max-width: 100%;
+  display: inline-block;
+}
+
+.plan-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+  border-radius: 8px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.plan-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.plan-overlay__rect {
+  position: absolute;
+  border-radius: 8px;
+  pointer-events: none;
+  border: 2px solid transparent;
+}
+
+.plan-overlay__rect--phase1 {
+  background: var(--accent1);
+  border-color: var(--accent1-border);
+}
+
+.plan-overlay__rect--phase2 {
+  background: var(--accent2);
+  border-color: var(--accent2-border);
+}
+
+.phase-tool__coordinates {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.phase-card {
+  border-radius: 12px;
+  padding: 16px;
+  background: #f9fafc;
+  border: 1px solid var(--border);
+}
+
+.phase-card h2 {
+  margin-top: 0;
+}
+
+.phase-card__coords {
+  margin: 8px 0 0 0;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+  font-size: 0.95rem;
+  color: var(--muted);
+  white-space: pre-wrap;
+}
+
+.phase-card--one {
+  border-left: 6px solid var(--accent1-border);
+}
+
+.phase-card--two {
+  border-left: 6px solid var(--accent2-border);
+}
+
+.phase-tool__export h2 {
+  margin-top: 0;
+}
+
+.phase-tool__json {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  min-height: 64px;
+}
+
+.phase-tool__copy {
+  margin-top: 12px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  background: #1b2a4b;
+  color: #ffffff;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+}
+
+.phase-tool__copy:hover {
+  background: #24345f;
+}
+
+.phase-tool__copy-status {
+  margin-top: 8px;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .phase-tool {
+    padding: 16px 12px 32px;
+  }
+}

--- a/public/admin-phases.html
+++ b/public/admin-phases.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Définir les phases du plan</title>
+  <link rel="stylesheet" href="/admin-phases.css">
+</head>
+<body>
+  <main class="phase-tool" id="app">
+    <header class="phase-tool__header">
+      <h1>Phases du plan</h1>
+      <p id="floor-label" class="phase-tool__floor">&nbsp;</p>
+    </header>
+
+    <section class="phase-tool__panel">
+      <div class="phase-tool__status" id="status-message"></div>
+      <div class="phase-tool__instructions">
+        <p>
+          Sélectionnez la phase à dessiner puis faites glisser la souris sur le plan pour tracer un
+          rectangle. Les coordonnées affichées correspondent aux pixels de l'image originale.
+        </p>
+      </div>
+      <div class="phase-tool__actions">
+        <button type="button" class="phase-button phase-button--active" data-phase="1">
+          Phase&nbsp;1 (jaune)
+        </button>
+        <button type="button" class="phase-button" data-phase="2">
+          Phase&nbsp;2 (rose)
+        </button>
+        <button type="button" class="phase-button phase-button--ghost" id="reset-phase">
+          Effacer la phase active
+        </button>
+      </div>
+    </section>
+
+    <section class="phase-tool__plan" id="plan-section">
+      <div class="plan-container">
+        <img id="floor-plan" alt="Plan de l'étage" class="plan-image" />
+        <div id="plan-overlay" class="plan-overlay"></div>
+      </div>
+    </section>
+
+    <section class="phase-tool__coordinates">
+      <article class="phase-card phase-card--one">
+        <h2>Phase 1</h2>
+        <p class="phase-card__coords" id="phase1-coords">Cliquez-glissez pour dessiner la zone.</p>
+      </article>
+      <article class="phase-card phase-card--two">
+        <h2>Phase 2</h2>
+        <p class="phase-card__coords" id="phase2-coords">Cliquez-glissez pour dessiner la zone.</p>
+      </article>
+    </section>
+
+    <section class="phase-tool__export">
+      <h2>JSON à copier dans <code>config/planPhases.js</code></h2>
+      <pre id="json-output" class="phase-tool__json">Aucun rectangle défini.</pre>
+      <button type="button" id="copy-json" class="phase-tool__copy">Copier</button>
+      <p class="phase-tool__copy-status" id="copy-status"></p>
+    </section>
+  </main>
+
+  <script type="module" src="/admin-phases.js"></script>
+</body>
+</html>

--- a/public/admin-phases.js
+++ b/public/admin-phases.js
@@ -1,0 +1,306 @@
+const buttons = Array.from(document.querySelectorAll('.phase-button[data-phase]'));
+const resetButton = document.getElementById('reset-phase');
+const statusMessage = document.getElementById('status-message');
+const floorLabel = document.getElementById('floor-label');
+const planImage = document.getElementById('floor-plan');
+const overlay = document.getElementById('plan-overlay');
+const jsonOutput = document.getElementById('json-output');
+const copyButton = document.getElementById('copy-json');
+const copyStatus = document.getElementById('copy-status');
+const coordsLabels = {
+  '1': document.getElementById('phase1-coords'),
+  '2': document.getElementById('phase2-coords')
+};
+
+const state = {
+  activePhase: '1',
+  floor: null,
+  naturalWidth: 0,
+  naturalHeight: 0,
+  boxes: { '1': null, '2': null },
+  drawing: null
+};
+
+const rectElements = {
+  '1': createRectElement('phase1'),
+  '2': createRectElement('phase2')
+};
+
+overlay.appendChild(rectElements['1']);
+overlay.appendChild(rectElements['2']);
+
+init();
+
+async function init() {
+  const params = new URLSearchParams(window.location.search);
+  const floorId = params.get('etage_id');
+
+  if (!floorId) {
+    setStatus('Ajoutez le paramètre "etage_id" à l’URL.');
+    disableInteractions();
+    return;
+  }
+
+  try {
+    const floor = await fetchFloor(floorId);
+    state.floor = floor;
+    floorLabel.textContent = floor.name ? `Étage : ${floor.name}` : `Étage n°${floor.id}`;
+    const planUrl = normalisePlanUrl(floor.plan_path);
+    if (!planUrl) {
+      setStatus('Aucun plan n’est enregistré pour cet étage.');
+      disableInteractions();
+      return;
+    }
+    await loadPlan(planUrl);
+    setStatus('Sélectionnez une phase puis dessinez un rectangle.');
+  } catch (err) {
+    console.error(err);
+    setStatus(err.message || 'Impossible de charger les informations de l’étage.');
+    disableInteractions();
+  }
+}
+
+function disableInteractions() {
+  planImage.style.opacity = '0.3';
+  buttons.forEach(btn => btn.disabled = true);
+  resetButton.disabled = true;
+  copyButton.disabled = true;
+}
+
+function setStatus(message) {
+  statusMessage.textContent = message || '';
+}
+
+function createRectElement(phase) {
+  const el = document.createElement('div');
+  const key = phase === '2' || phase === 'phase2' ? 'phase2' : 'phase1';
+  el.className = `plan-overlay__rect plan-overlay__rect--${key}`;
+  el.style.display = 'none';
+  return el;
+}
+
+async function fetchFloor(id) {
+  const response = await fetch(`/api/floors/${encodeURIComponent(id)}`);
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error('Étage introuvable.');
+    }
+    throw new Error('Erreur lors de la récupération de l’étage.');
+  }
+  return response.json();
+}
+
+function normalisePlanUrl(planPath) {
+  if (!planPath) return null;
+  if (/^https?:/i.test(planPath)) return planPath;
+  const cleaned = String(planPath).replace(/^\/+/, '');
+  return `/${cleaned}`;
+}
+
+function loadPlan(src) {
+  return new Promise((resolve, reject) => {
+    planImage.addEventListener('load', () => {
+      state.naturalWidth = planImage.naturalWidth;
+      state.naturalHeight = planImage.naturalHeight;
+      if (!state.naturalWidth || !state.naturalHeight) {
+        reject(new Error('Impossible de récupérer les dimensions du plan.'));
+        return;
+      }
+      syncOverlaySize();
+      window.addEventListener('resize', syncOverlaySize);
+      enableDrawing();
+      resolve();
+    }, { once: true });
+    planImage.addEventListener('error', () => {
+      reject(new Error('Impossible de charger l’image du plan.'));
+    }, { once: true });
+    planImage.src = src;
+  });
+}
+
+function syncOverlaySize() {
+  const width = planImage.clientWidth;
+  const height = planImage.clientHeight;
+  if (!width || !height) return;
+  overlay.style.width = `${width}px`;
+  overlay.style.height = `${height}px`;
+  overlay.style.left = `${planImage.offsetLeft}px`;
+  overlay.style.top = `${planImage.offsetTop}px`;
+  overlay.style.pointerEvents = 'auto';
+  redrawRectangles();
+}
+
+function enableDrawing() {
+  overlay.addEventListener('mousedown', onPointerDown);
+  window.addEventListener('mousemove', onPointerMove);
+  window.addEventListener('mouseup', onPointerUp);
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const phase = btn.getAttribute('data-phase');
+      if (!phase) return;
+      state.activePhase = phase;
+      buttons.forEach(b => b.classList.toggle('phase-button--active', b === btn));
+    });
+  });
+
+  resetButton.addEventListener('click', () => {
+    if (!state.activePhase) return;
+    setBox(state.activePhase, null);
+  });
+
+  copyButton.addEventListener('click', onCopy);
+}
+
+function getRelativePosition(event) {
+  const rect = overlay.getBoundingClientRect();
+  const x = Math.min(Math.max(event.clientX - rect.left, 0), rect.width);
+  const y = Math.min(Math.max(event.clientY - rect.top, 0), rect.height);
+  return { x, y };
+}
+
+function onPointerDown(event) {
+  if (event.button !== 0) return;
+  if (!state.naturalWidth || !state.naturalHeight) return;
+  event.preventDefault();
+  overlay.style.cursor = 'crosshair';
+  const start = getRelativePosition(event);
+  state.drawing = {
+    phase: state.activePhase,
+    start,
+    rect: { left: start.x, top: start.y, width: 0, height: 0 }
+  };
+  setBox(state.activePhase, null, { silent: true });
+  updateRectDisplay(state.activePhase, state.drawing.rect);
+}
+
+function onPointerMove(event) {
+  if (!state.drawing) return;
+  const current = getRelativePosition(event);
+  const { start } = state.drawing;
+  const left = Math.min(start.x, current.x);
+  const top = Math.min(start.y, current.y);
+  const width = Math.abs(current.x - start.x);
+  const height = Math.abs(current.y - start.y);
+  state.drawing.rect = { left, top, width, height };
+  updateRectDisplay(state.drawing.phase, state.drawing.rect);
+}
+
+function onPointerUp() {
+  overlay.style.cursor = '';
+  if (!state.drawing) return;
+  const { phase, rect } = state.drawing;
+  state.drawing = null;
+  if (!rect || rect.width < 5 || rect.height < 5) {
+    setBox(phase, null);
+    return;
+  }
+  const scaleX = state.naturalWidth / overlay.clientWidth;
+  const scaleY = state.naturalHeight / overlay.clientHeight;
+  const box = {
+    left: Math.round(rect.left * scaleX),
+    top: Math.round(rect.top * scaleY),
+    width: Math.round(rect.width * scaleX),
+    height: Math.round(rect.height * scaleY)
+  };
+  setBox(phase, box);
+}
+
+function setBox(phase, box, options = {}) {
+  state.boxes[phase] = box;
+  if (!options.silent) {
+    updateCoords(phase);
+    redrawRectangles();
+    updateJson();
+  }
+}
+
+function updateRectDisplay(phase, rect) {
+  const el = rectElements[phase];
+  if (!el) return;
+  if (!rect || rect.width <= 0 || rect.height <= 0) {
+    el.style.display = 'none';
+    return;
+  }
+  el.style.display = 'block';
+  el.style.left = `${rect.left}px`;
+  el.style.top = `${rect.top}px`;
+  el.style.width = `${rect.width}px`;
+  el.style.height = `${rect.height}px`;
+}
+
+function redrawRectangles() {
+  const displayWidth = overlay.clientWidth;
+  const displayHeight = overlay.clientHeight;
+  if (!displayWidth || !displayHeight) return;
+  const scaleX = displayWidth / state.naturalWidth;
+  const scaleY = displayHeight / state.naturalHeight;
+  for (const phase of ['1', '2']) {
+    const box = state.boxes[phase];
+    if (!box) {
+      updateRectDisplay(phase, null);
+      continue;
+    }
+    const rect = {
+      left: box.left * scaleX,
+      top: box.top * scaleY,
+      width: box.width * scaleX,
+      height: box.height * scaleY
+    };
+    updateRectDisplay(phase, rect);
+  }
+  updateCoords('1');
+  updateCoords('2');
+  updateJson();
+}
+
+function updateCoords(phase) {
+  const el = coordsLabels[phase];
+  if (!el) return;
+  const box = state.boxes[phase];
+  if (!box) {
+    el.textContent = 'Cliquez-glissez pour dessiner la zone.';
+    return;
+  }
+  el.textContent = `left: ${box.left}px\ntop: ${box.top}px\nwidth: ${box.width}px\nheight: ${box.height}px`;
+}
+
+async function onCopy() {
+  const text = jsonOutput.textContent.trim();
+  if (!text || text === 'Aucun rectangle défini.') {
+    copyStatus.textContent = 'Définissez au moins un rectangle.';
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    copyStatus.textContent = 'Copié dans le presse-papiers !';
+  } catch (err) {
+    console.error(err);
+    copyStatus.textContent = 'Impossible de copier automatiquement. Sélectionnez le texte manuellement.';
+  }
+}
+
+function updateJson() {
+  const floorName = state.floor?.name?.trim();
+  const box1 = state.boxes['1'];
+  const box2 = state.boxes['2'];
+  if (!box1 && !box2) {
+    jsonOutput.textContent = 'Aucun rectangle défini.';
+    copyStatus.textContent = '';
+    return;
+  }
+  const label = floorName || `Etage ${state.floor?.id ?? ''}`;
+  const lines = [`'${escapeLabel(label)}': {`];
+  const formatBox = box => box
+    ? `{ left: ${box.left}, top: ${box.top}, width: ${box.width}, height: ${box.height} }`
+    : 'null';
+  lines.push(`  '1': ${formatBox(box1)},`);
+  lines.push(`  '2': ${formatBox(box2)}`);
+  lines.push('}');
+  jsonOutput.textContent = lines.join('\n');
+  copyStatus.textContent = '';
+}
+
+function escapeLabel(label) {
+  return String(label).replace(/'/g, "\\'");
+}

--- a/routes/floors.js
+++ b/routes/floors.js
@@ -57,6 +57,24 @@ router.post('/:id/plan', upload.single('plan'), async (req, res) => {
   }
 });
 
+// Récupération d'un étage par son identifiant
+router.get('/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { rows } = await pool.query(
+      'SELECT id, name, plan_path FROM floors WHERE id = $1',
+      [id]
+    );
+    if (!rows.length) {
+      return res.status(404).json({ error: 'Étage introuvable' });
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Erreur GET /api/floors/:id', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
 // GET du plan
 router.get('/:id/plan', async (req, res) => {
   const { id } = req.params;

--- a/server.js
+++ b/server.js
@@ -161,6 +161,9 @@ app.use(express.static(path.join(__dirname, "public")));
 
 // Toutes les routes suivantes nécessitent l'authentification
 app.use(isAuthenticated);
+app.get('/admin/phases', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'admin-phases.html'));
+});
 // Route pour récupérer la liste des chantiers
 app.use('/api/chantiers', chantiersRoutes);
 


### PR DESCRIPTION
## Summary
- add an authenticated /admin/phases helper page to draw phase rectangles on a floor plan and copy JSON for planPhases.js
- serve the admin helper page directly from Express and expose GET /api/floors/:id for plan metadata
- bundle dedicated styles and scripts for the drawing UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d035cae8cc8328b7b963dd1bb7d7bb