### PR TITLE
Add phase export option to index page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -102,6 +102,14 @@
       <option value="xlsx">Excel</option>
       <option value="pdf">PDF</option>
     </select>
+    <label>Phase :
+      <select id="phaseSelect">
+        <option value="">(Aucune)</option>
+        <option value="1">Phase 1</option>
+        <option value="2">Phase 2</option>
+        <option value="all">Toutes</option>
+      </select>
+    </label>
     <fieldset id="export-columns">
       <legend>Colonnes à inclure :</legend>
       <label><input type="checkbox" name="col" value="id" checked> ID</label>
@@ -123,6 +131,7 @@
       <label><input type="checkbox" name="col" value="levee_fait_le" checked> Fait le</label>
       <label><input type="checkbox" name="col" value="levee_commentaire" checked> Levée – Commentaire</label>
     </fieldset>
+    <button id="exportPhaseBtn">Exporter (par phase)</button>
     <!-- Nouveau bouton Export -->
     <button id="exportBtn">Exporter</button>
 

--- a/public/script.js
+++ b/public/script.js
@@ -32,14 +32,16 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function initApp() {
-    const chantierSelect  = document.getElementById("chantierSelect");
-    const etageSelect     = document.getElementById("etageSelect");
-    const chambreSelect   = document.getElementById("chambreSelect");
-    const exportBtn    = document.getElementById("exportBtn");
-    const formatSelect = document.getElementById("export-format");
-    const plan            = document.getElementById("plan");
-    const bullesContainer = document.getElementById("bulles-container");
-    const statusFilter    = document.getElementById("statusFilter");
+    const chantierSelect   = document.getElementById("chantierSelect");
+    const etageSelect      = document.getElementById("etageSelect");
+    const chambreSelect    = document.getElementById("chambreSelect");
+    const exportBtn        = document.getElementById("exportBtn");
+    const exportPhaseBtn   = document.getElementById("exportPhaseBtn");
+    const formatSelect     = document.getElementById("export-format");
+    const phaseSelect      = document.getElementById("phaseSelect");
+    const plan             = document.getElementById("plan");
+    const bullesContainer  = document.getElementById("bulles-container");
+    const statusFilter     = document.getElementById("statusFilter");
 
     // Fonction de filtrage des bulles selon l'état sélectionné
     function filterBulles() {
@@ -272,7 +274,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch(`/api/floors?chantier_id=${chantierId}`, { credentials:'include' });
       const etages = await res.json();
       etageSelect.innerHTML = etages.map(e =>
-        `<option value="${e.id}">${e.name}</option>`
+        `<option value="${e.id}" data-floor-id="${e.id}">${e.name}</option>`
       ).join('');
       if (!etages.length) return;
       etageSelect.selectedIndex = 0;
@@ -853,8 +855,29 @@ document.addEventListener('DOMContentLoaded', () => {
       updateRoomOptions(id);
       loadBulles();
     };
-      chambreSelect.onchange = loadBulles;
-      exportBtn.onclick = async () => {
+    chambreSelect.onchange = loadBulles;
+    if (exportPhaseBtn) {
+      exportPhaseBtn.addEventListener('click', () => {
+        const fmt = (formatSelect?.value || 'csv').toLowerCase();
+        const selectedOption = etageSelect?.selectedOptions?.[0];
+        const etageId = selectedOption?.dataset?.floorId
+          || selectedOption?.value
+          || etageSelect?.value;
+        if (!etageId) {
+          console.warn('Impossible de déterminer etage_id pour export phase');
+          return;
+        }
+        const phaseValue = phaseSelect?.value || '';
+        const url = new URL('/api/bulles/export', window.location.origin);
+        url.searchParams.set('format', fmt);
+        url.searchParams.set('etage_id', etageId);
+        if (phaseValue) {
+          url.searchParams.set('phase', phaseValue);
+        }
+        window.open(url.toString(), '_blank');
+      });
+    }
+    exportBtn.onclick = async () => {
         const fmt = (formatSelect.value || 'csv').toLowerCase();
         if (fmt !== 'pdf') {
           const params = new URLSearchParams();


### PR DESCRIPTION
## Summary
- add a phase selector and Exporter (par phase) button to the index export controls
- wire the new button to open /api/bulles/export with the selected format, etage_id, and optional phase
- include data-floor-id metadata on dynamically generated floor options so the export can read the floor id

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d0520edbb4832888cb4b17021390a4