### PR TITLE
Add SSL configuration for export script pool

### DIFF
--- a/scripts/exportBulles.js
+++ b/scripts/exportBulles.js
@@ -4,7 +4,12 @@ const path = require("path");
 const { Pool } = require("pg");
 const ExcelJS = require("exceljs");
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: {
+    rejectUnauthorized: false,
+  },
+});
 
 const pad2 = (n) => String(n).padStart(2, "0");
 function formatDate(val) {


### PR DESCRIPTION
## Summary
- update the export script's PostgreSQL pool to enforce SSL connections while accepting provided certificates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db8d1446c08328b18fd81f7b9d243e