### PR TITLE
Center login layout on all devices

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -46,6 +46,8 @@ body {
   align-items: center;
   justify-content: center;
   padding: clamp(2rem, 5vw, 4rem);
+  margin-inline: auto;
+  width: min(960px, 100%);
   background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.35), transparent 55%),
               radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.3), transparent 50%),
               linear-gradient(135deg, #0f172a 0%, #1f2937 45%, #111827 100%);
@@ -53,6 +55,19 @@ body {
   overflow: hidden;
   border-radius: 24px;
   box-shadow: 0 35px 120px rgba(15, 23, 42, 0.35);
+}
+
+@media (min-width: 768px) {
+  .auth-wrapper {
+    width: min(720px, calc(100% - 6rem));
+  }
+}
+
+@media (max-width: 600px) {
+  .auth-wrapper {
+    width: min(100%, calc(100% - 1.5rem));
+    padding: clamp(1.5rem, 7vw, 2.75rem);
+  }
 }
 
 .auth-wrapper::before,


### PR DESCRIPTION
## Summary
- center the login wrapper by constraining its width and using auto margins
- refine responsive rules so the login card keeps balanced spacing on mobile

## Testing
- npm start *(fails: database connection is unreachable in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68dd244e2f9083289536d5d6c470a4a7