### PR TITLE
Improve login safe area handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
   <link rel="icon" href="/img/brh-logo.png" type="image/png">
 </head>
-<body>
+<body class="login-page">
   <div id="sidebar-holder"></div>
   <link rel="stylesheet" href="/sidebar.css">
   <script src="/sidebar.js" defer></script>

--- a/public/script.js
+++ b/public/script.js
@@ -10,6 +10,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const loginError = document.getElementById('login-error');
   const appContainer = document.getElementById('app-container');
   const logoutBtn = document.getElementById('logoutBtn');
+  const body = document.body;
+
+  const setLoginVisible = (isVisible) => {
+    if (isVisible) {
+      body.classList.add('login-page');
+    } else {
+      body.classList.remove('login-page');
+    }
+    loginContainer.style.display = isVisible ? 'block' : 'none';
+    appContainer.style.display = isVisible ? 'none' : 'block';
+  };
 
   let user = null;
   const ADMIN_EMAIL_KEYWORDS = ['launay', 'blot', 'athari', 'mirona'];
@@ -26,15 +37,14 @@ document.addEventListener('DOMContentLoaded', () => {
       if (res.ok) {
         const data = await res.json();
         user = data.user;
-        loginContainer.style.display = 'none';
-        appContainer.style.display = 'block';
+        setLoginVisible(false);
         await initApp();
       } else {
-        loginContainer.style.display = 'block';
-        appContainer.style.display = 'none';
+        setLoginVisible(true);
       }
     } catch (err) {
       console.error(err);
+      setLoginVisible(true);
     }
   }
 
@@ -1166,14 +1176,14 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await res.json();
       user = data.user;
       loginError.textContent = '';
-      loginContainer.style.display = 'none';
-      appContainer.style.display   = 'block';
+      setLoginVisible(false);
       // Render the sidebar now that we are authenticated
       if (window.renderSidebar) {
         try { await window.renderSidebar(); } catch(_){ }
       }
       await initApp();
     } else {
+      setLoginVisible(true);
       loginError.textContent = 'Échec de la connexion';
     }
   });
@@ -1197,5 +1207,6 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = 'historique.html';
   });
 
+  setLoginVisible(true);
   refresh();
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -674,9 +674,20 @@ html[data-theme="dark"], body[data-theme="dark"]{ --card-bg:rgba(255,255,255,0.0
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: calc(100vh - 80px); /* 80px ≈ hauteur d’en-tête, ajuste au besoin */
-  padding: 16px;                  /* évite la coupe côté droit sur mobile */
+  min-height: 100svh;   /* hauteur plein écran, fiable sur mobile */
+  padding: 16px;
+  padding-inline: max(16px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
+  padding-block: max(16px, env(safe-area-inset-top, 0px), env(safe-area-inset-bottom, 0px));
   box-sizing: border-box;
+
+  /* 🌈 Fond dégradé uniquement pour la page login */
+  background: linear-gradient(135deg, #0b1c2e 0%, #122b45 50%, #143d64 100%);
+}
+
+/* Neutralise les fonds globaux derrière le login */
+body.login-page,
+body.login-page #app-container {
+  background: transparent !important;
 }
 
 #login-container .auth-wrapper {


### PR DESCRIPTION
## Summary
- update the login container to use `100svh` for full-height centering
- add a dedicated gradient background so the login page fills the viewport
- protect the gradient with safe-area padding and neutralize global backgrounds with a login body class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd2c2b90508328831df5010370d180