### PR TITLE
Fix login gradient container layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,8 +15,10 @@
   <!-- Librairies pour l’export PDF -->
   <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.4/dist/jspdf.plugin.autotable.min.js"></script>
-  <div id="login-container" class="auth-wrapper">
-    <div class="auth-card">
+  <!-- ⚠️ login-container = fond plein écran ; auth-wrapper = largeur contrainte -->
+  <div id="login-container">
+    <div class="auth-wrapper">
+      <div class="auth-card">
       <div class="auth-brand">
         <img src="/img/brh-logo.png" alt="Bâti Rénov Hôtellerie" class="auth-logo" />
         <div class="auth-heading">
@@ -45,7 +47,8 @@
       <div class="auth-footer">
         <small>Assistance : <a href="mailto:support@bati-renov-hotellerie.fr">support@bati-renov-hotellerie.fr</a></small>
       </div>
-    </div>
+      </div><!-- /.auth-card -->
+    </div><!-- /.auth-wrapper -->
   </div>
 
   <div id="app-container" style="display:none;">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,9 @@
+/* Assure qu'il n'y a pas de marge et que 100% hauteur est bien pris */
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
 /* === Thème clair/sombre : variables minimales non-intrusives === */
 :root{
   --bg:#ffffff;
@@ -675,6 +681,8 @@ html[data-theme="dark"], body[data-theme="dark"]{ --card-bg:rgba(255,255,255,0.0
   align-items: center;
   justify-content: center;
   min-height: 100svh;   /* hauteur plein écran, fiable sur mobile */
+  width: 100%;
+  min-width: 100%;
   padding: 16px;
   padding-inline: max(16px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
   padding-block: max(16px, env(safe-area-inset-top, 0px), env(safe-area-inset-bottom, 0px));
@@ -690,14 +698,14 @@ body.login-page #app-container {
   background: transparent !important;
 }
 
-#login-container .auth-wrapper {
+.auth-wrapper {
   width: 100%;
   max-width: 480px;               /* largeur carte login */
   margin: 0;                      /* on laisse le parent gérer le centrage */
 }
 
 @media (min-width: 768px) {
-  #login-container .auth-wrapper {
+  .auth-wrapper {
     max-width: 520px;
   }
 }


### PR DESCRIPTION
## Summary
- move the auth wrapper inside the full-screen login container so the gradient covers the entire viewport
- ensure the login container always spans the full width and add global height defaults so the background renders correctly

## Testing
- npm start *(fails: ENETUNREACH to remote PostgreSQL host)*

------
https://chatgpt.com/codex/tasks/task_b_68dd2ffe3fdc8328bcb5c0b6d351abc4