### PR TITLE
feat: open export configuration in modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -121,45 +121,52 @@
       </div>
     </div>
 
-    <!-- Format d’export -->
-    <label for="export-format">Format :</label>
-    <select id="export-format">
-      <option value="csv">CSV</option>
-      <option value="xlsx">Excel</option>
-      <option value="pdf">PDF</option>
-    </select>
-    <label>Phase :
-      <select id="phaseSelect">
-        <option value="">(Aucune)</option>
-        <option value="1">Phase 1</option>
-        <option value="2">Phase 2</option>
-        <option value="all">Toutes</option>
-      </select>
-    </label>
-    <fieldset id="export-columns">
-      <legend>Colonnes à inclure :</legend>
-      <label><input type="checkbox" name="col" value="id" checked> ID</label>
-      <label><input type="checkbox" name="col" value="created_by_email" checked> Utilisateur</label>
-      <label><input type="checkbox" name="col" value="modified_by_email"> Modifié par (email)</label>
-      <label><input type="checkbox" name="col" value="etage" checked> Étage</label>
-      <label><input type="checkbox" name="col" value="chambre" checked> Chambre</label>
-      <label><input type="checkbox" name="col" value="numero" checked> N°</label>
-      <label><input type="checkbox" name="col" value="lot" checked> Lot</label>
-      <label><input type="checkbox" name="col" value="intitule" checked> Intitulé</label>
-      <label><input type="checkbox" name="col" value="description"> Description</label>
-      <label><input type="checkbox" name="col" value="etat" checked> État</label>
-      <label><input type="checkbox" name="col" value="localisation"> Localisation</label>
-      <label><input type="checkbox" name="col" value="observation" checked> Observation</label>
-      <label><input type="checkbox" name="col" value="date_butoir"> Date butoir</label>
-      <label><input type="checkbox" name="col" value="photos" checked> Photos (tous les liens)</label>
-      <label><input type="checkbox" name="col" value="videos" checked> Vidéos (tous les liens)</label>
-      <label><input type="checkbox" name="col" value="levee_fait_par_email" checked> Fait par</label>
-      <label><input type="checkbox" name="col" value="levee_fait_le" checked> Fait le</label>
-      <label><input type="checkbox" name="col" value="levee_commentaire" checked> Levée – Commentaire</label>
-    </fieldset>
     <button id="exportPhaseBtn">Exporter (par phase)</button>
-    <!-- Nouveau bouton Export -->
-    <button id="exportBtn">Exporter</button>
+    <button id="openExportBtn">Exporter</button>
+
+    <div id="exportModal" class="modal" hidden>
+      <div class="modal-dialog export-modal" role="dialog" aria-modal="true" aria-labelledby="exportModalTitle">
+        <button type="button" class="close-btn" id="exportCloseBtn" aria-label="Fermer">×</button>
+        <h2 id="exportModalTitle">Exporter les données</h2>
+        <label for="export-format">Format :</label>
+        <select id="export-format">
+          <option value="csv">CSV</option>
+          <option value="xlsx">Excel</option>
+          <option value="pdf">PDF</option>
+        </select>
+        <label for="phaseSelect">Phase :</label>
+        <select id="phaseSelect">
+          <option value="">(Aucune)</option>
+          <option value="1">Phase 1</option>
+          <option value="2">Phase 2</option>
+          <option value="all">Toutes</option>
+        </select>
+        <fieldset id="export-columns">
+          <legend>Colonnes à inclure :</legend>
+          <label><input type="checkbox" name="col" value="id" checked> ID</label>
+          <label><input type="checkbox" name="col" value="created_by_email" checked> Utilisateur</label>
+          <label><input type="checkbox" name="col" value="modified_by_email"> Modifié par (email)</label>
+          <label><input type="checkbox" name="col" value="etage" checked> Étage</label>
+          <label><input type="checkbox" name="col" value="chambre" checked> Chambre</label>
+          <label><input type="checkbox" name="col" value="numero" checked> N°</label>
+          <label><input type="checkbox" name="col" value="lot" checked> Lot</label>
+          <label><input type="checkbox" name="col" value="intitule" checked> Intitulé</label>
+          <label><input type="checkbox" name="col" value="description"> Description</label>
+          <label><input type="checkbox" name="col" value="etat" checked> État</label>
+          <label><input type="checkbox" name="col" value="localisation"> Localisation</label>
+          <label><input type="checkbox" name="col" value="observation" checked> Observation</label>
+          <label><input type="checkbox" name="col" value="date_butoir"> Date butoir</label>
+          <label><input type="checkbox" name="col" value="photos" checked> Photos (tous les liens)</label>
+          <label><input type="checkbox" name="col" value="videos" checked> Vidéos (tous les liens)</label>
+          <label><input type="checkbox" name="col" value="levee_fait_par_email" checked> Fait par</label>
+          <label><input type="checkbox" name="col" value="levee_fait_le" checked> Fait le</label>
+          <label><input type="checkbox" name="col" value="levee_commentaire" checked> Levée – Commentaire</label>
+        </fieldset>
+        <div class="modal-actions">
+          <button id="exportBtn" class="btn-primary">Exporter</button>
+        </div>
+      </div>
+    </div>
 
     <div id="plan-container">
       <img id="plan" src="plan-r5.png" alt="Plan étage" />

--- a/public/script.js
+++ b/public/script.js
@@ -52,8 +52,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const chantierSelect   = document.getElementById("chantierSelect");
     const etageSelect      = document.getElementById("etageSelect");
     const chambreSelect    = document.getElementById("chambreSelect");
+    const openExportBtn    = document.getElementById("openExportBtn");
     const exportBtn        = document.getElementById("exportBtn");
     const exportPhaseBtn   = document.getElementById("exportPhaseBtn");
+    const exportModal      = document.getElementById("exportModal");
+    const exportCloseBtn   = document.getElementById("exportCloseBtn");
     const formatSelect     = document.getElementById("export-format");
     const phaseSelect      = document.getElementById("phaseSelect");
     const plan             = document.getElementById("plan");
@@ -912,6 +915,30 @@ document.addEventListener('DOMContentLoaded', () => {
       loadBulles();
     };
     chambreSelect.onchange = loadBulles;
+    const closeExportModal = () => {
+      if (exportModal) {
+        exportModal.hidden = true;
+      }
+    };
+
+    if (openExportBtn && exportModal) {
+      openExportBtn.addEventListener('click', () => {
+        exportModal.hidden = false;
+      });
+    }
+
+    if (exportCloseBtn) {
+      exportCloseBtn.addEventListener('click', closeExportModal);
+    }
+
+    if (exportModal) {
+      exportModal.addEventListener('click', (event) => {
+        if (event.target === exportModal) {
+          closeExportModal();
+        }
+      });
+    }
+
     if (exportPhaseBtn) {
       exportPhaseBtn.addEventListener('click', () => {
         const fmt = (formatSelect?.value || 'csv').toLowerCase();
@@ -933,8 +960,10 @@ document.addEventListener('DOMContentLoaded', () => {
         window.open(url.toString(), '_blank');
       });
     }
-    exportBtn.onclick = async () => {
-        const fmt = (formatSelect.value || 'csv').toLowerCase();
+
+    if (exportBtn) {
+      exportBtn.addEventListener('click', async () => {
+        const fmt = (formatSelect?.value || 'csv').toLowerCase();
         if (fmt !== 'pdf') {
           const params = new URLSearchParams();
           params.set('chantier_id', chantierSelect.value);
@@ -944,6 +973,7 @@ document.addEventListener('DOMContentLoaded', () => {
           document.querySelectorAll('#export-columns input[name="col"]:checked')
             .forEach(cb => params.append('columns', cb.value));
           window.open(`/api/bulles/export?${params.toString()}`, '_blank');
+          closeExportModal();
           return;
         }
 
@@ -968,6 +998,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (!window.jspdf || !window.jspdf.jsPDF) {
           alert('Export PDF indisponible (librairies non chargées)');
+          closeExportModal();
           return;
         }
 
@@ -1155,7 +1186,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         doc.save('export_bulles_' + new Date().toISOString().slice(0,10) + '.pdf');
-      };
+        closeExportModal();
+      });
 
     window.addEventListener('resize', ajusterTailleBulles);
     window.addEventListener('orientationchange', ajusterTailleBulles);

--- a/public/styles.css
+++ b/public/styles.css
@@ -716,3 +716,113 @@ body.login-page #app-container {
   margin: 0;                      /* la carte suit la largeur max ci-dessus */
   border-radius: 14px;
 }
+
+/* -------------------------------------------------- */
+/* Export modal                                       */
+/* -------------------------------------------------- */
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-dialog {
+  position: relative;
+  background: var(--card-bg, #ffffff);
+  color: inherit;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+  width: min(90vw, 520px);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-dialog h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.4rem;
+}
+
+.modal-dialog label {
+  display: block;
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.35rem;
+}
+
+.modal-dialog select,
+.modal-dialog input[type="checkbox"] {
+  font: inherit;
+}
+
+.modal-dialog select,
+.modal-dialog fieldset {
+  width: 100%;
+}
+
+.modal-dialog fieldset {
+  margin-top: 1.25rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.modal-dialog fieldset legend {
+  font-weight: 600;
+  padding: 0 0.25rem;
+}
+
+.modal-dialog fieldset label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  margin-top: 0.5rem;
+}
+
+.modal-dialog fieldset label:first-of-type {
+  margin-top: 0;
+}
+
+.modal-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal-actions .btn-primary {
+  min-width: 160px;
+}
+
+.close-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  line-height: 1;
+  color: inherit;
+}
+
+#exportModal select {
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: var(--input-bg, #fff);
+}
+
+#exportModal fieldset label input[type="checkbox"] {
+  accent-color: #007bff;
+}


### PR DESCRIPTION
## Summary
- replace the inline export configuration controls with a modal opened from the Export button
- add shared modal styling for the export dialog and keep existing column selectors inside it
- wire up modal open/close logic so exports close the popup after triggering the download

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd38522b70832883110ce22d835bfd